### PR TITLE
refactor: prevent flickering and cleaning up

### DIFF
--- a/packages/sn-filter-pane/src/data/index.ts
+++ b/packages/sn-filter-pane/src/data/index.ts
@@ -1,8 +1,9 @@
 import extend from 'extend';
 import { store } from '../store';
 import { defaultListboxProps } from './listbox-properties';
+import { IConfig, IEnv } from '../types/types';
 
-export default function getData(env) {
+export default function getData(env: IEnv) {
   const { translator } = env;
 
   return {
@@ -11,17 +12,6 @@ export default function getData(env) {
       max: 1000,
     },
     measures: { min: 0, max: 0 },
-    // qListObjectDef: {
-    //   qShowAlternatives: true,
-    //   qInitialDataFetch: [
-    //     {
-    //       qLeft: 0,
-    //       qWidth: 1,
-    //       qTop: 0,
-    //       qHeight: 100,
-    //     },
-    //   ],
-    // },
     targets: [
       {
         path: '/qChildListDef/qDef/qListObjectDef',
@@ -43,12 +33,7 @@ export default function getData(env) {
 
             filterPaneModel?.createChild(listboxProps, data);
           },
-          move(/* dimension, data */) {
-            // setMoveSort(data);
-            // setColorVars(data);
-            // customTooltipUtils.moveCallbackCustomTooltip(data, dimension);
-          },
-          remove(dimension, data, index) {
+          remove(_dimension: EngineAPI.INxDimension, data: EngineAPI.IGenericObjectProperties, index: number) {
             const { fpLayout, model: filterPaneModel } = store.getState();
 
             const { qItems = [] } = fpLayout?.qChildList || {};
@@ -58,10 +43,7 @@ export default function getData(env) {
               filterPaneModel?.destroyChild(qId, data);
             }
           },
-          replace(/* dimension, oldDimension, index, data */) {
-            console.log('replace dimension');
-          },
-          description(_: unknown, __: unknown, config: Config): string {
+          description(_: unknown, __: unknown, config: IConfig): string {
             const translationProperty = config && config.type === 'rows' ? 'Visualizations.Descriptions.Row' : 'Visualizations.Descriptions.Column';
             return translator.get(translationProperty);
           },

--- a/packages/sn-filter-pane/src/hooks/use-render.ts
+++ b/packages/sn-filter-pane/src/hooks/use-render.ts
@@ -23,7 +23,7 @@ export default function useRender() {
     getListBoxResources(app, fpLayout).then((resArr: ListboxResourcesArr) => {
       setResourcesArr(resArr || []);
     });
-  }, [app, fpLayout]);
+  }, []);
 
   useEffect(() => {
     if (!resourcesArr?.length || !app) {

--- a/packages/sn-filter-pane/src/hooks/use-render.ts
+++ b/packages/sn-filter-pane/src/hooks/use-render.ts
@@ -14,6 +14,10 @@ export default function useRender() {
     app, fpLayout, options, constraints,
   } = store.getState();
 
+  // Create a string representation of the dim identities so that only a 
+  // change to these identities will trigger a re-render (fixes issue #7).
+  const listboxIdsString = fpLayout?.qChildList?.qItems.map(qItem => qItem?.qInfo?.qId).join(',');
+
   const containerElement = <IContainerElement>useElement();
 
   useEffect(() => {
@@ -23,7 +27,7 @@ export default function useRender() {
     getListBoxResources(app, fpLayout).then((resArr: ListboxResourcesArr) => {
       setResourcesArr(resArr || []);
     });
-  }, []);
+  }, [listboxIdsString]);
 
   useEffect(() => {
     if (!resourcesArr?.length || !app) {

--- a/packages/sn-filter-pane/src/types/types.d.ts
+++ b/packages/sn-filter-pane/src/types/types.d.ts
@@ -7,10 +7,15 @@ export interface IEnv {
     isEnabled: (flag?: string) => boolean;
   },
   sense?: ISense,
+  translator?: stardust.Translator | undefined,
 }
 
 export interface IConstraints {
   active?: boolean;
   passive?: boolean;
   select?: boolean;
+}
+
+export interface IConfig {
+  type: 'rows' | 'columns';
 }


### PR DESCRIPTION
Changes:
- Prevent re-rendering each time layout changes Fix(#7)
- Clean up, add types and remove code for unneeded dimension operations (we only need `add` and `remove`)