### PR TITLE
feat: use resource store

### DIFF
--- a/packages/sn-filter-pane/src/components/ListboxContainer.tsx
+++ b/packages/sn-filter-pane/src/components/ListboxContainer.tsx
@@ -15,7 +15,12 @@ const ListboxContainer = ({
   const [listboxInstance, setListboxInstance] = useState<stardust.FieldInstance>();
   const elRef = useRef<HTMLElement>();
 
-  const { embed, model, constraints, options } = store.getState();
+  const {
+    embed,
+    model,
+    constraints,
+    options,
+  } = store.getState();
 
   useEffect(() => {
     if (!layout || !embed) {

--- a/packages/sn-filter-pane/src/components/ListboxGrid/ListboxGrid.tsx
+++ b/packages/sn-filter-pane/src/components/ListboxGrid/ListboxGrid.tsx
@@ -7,7 +7,7 @@ import { styled } from '@mui/material/styles';
 import { ResizableBox } from 'react-resizable';
 import debounce from 'lodash/debounce';
 import getWidthHeight from './get-size';
-import { IListBoxOptions, IListboxResource } from '../../hooks/types';
+import { IListboxResource } from '../../hooks/types';
 import ListboxContainer from '../ListboxContainer';
 import 'react-resizable/css/styles.css';
 import ElementResizeListener from '../ElementResizeListener';
@@ -19,22 +19,17 @@ import { ColumnGrid } from './grid-components/ColumnGrid';
 import { Column } from './grid-components/Column';
 import { ColumnItem } from './grid-components/ColumnItem';
 import ConditionalWrapper from './ConditionalWrapper';
-import { store } from '../../store';
+import { store, useResourceStore } from '../../store';
 import { ListboxPopoverContainer } from '../ListboxPopoverContainer';
-
-export interface ListboxGridProps {
-  listboxOptions: IListBoxOptions;
-  resources: IListboxResource[];
-}
 
 // TODO: Remove
 const Resizable = styled(ResizableBox)(() => ({
   position: 'absolute',
 }));
 
-export default function ListboxGrid(props: ListboxGridProps) {
-  const { resources } = props;
+function ListboxGrid() {
   const { sense } = store.getState();
+  const resources = useResourceStore((state) => state.resources);
 
   const gridRef = useRef<HTMLDivElement>();
   const [columns, setColumns] = useState<IColumn[]>([]);
@@ -57,7 +52,7 @@ export default function ListboxGrid(props: ListboxGridProps) {
     if (gridRef.current) {
       handleResize();
     }
-  }, []);
+  }, [resources]);
 
   const dHandleResize = debounce(handleResize, isInSense ? 0 : 50);
 
@@ -105,3 +100,5 @@ export default function ListboxGrid(props: ListboxGridProps) {
     </>
   );
 }
+
+export default ListboxGrid;

--- a/packages/sn-filter-pane/src/components/root.tsx
+++ b/packages/sn-filter-pane/src/components/root.tsx
@@ -2,14 +2,14 @@ import React from 'react';
 import { createRoot, Root } from 'react-dom/client';
 import { ThemeProvider } from '@mui/material/styles';
 import { IContainerElement } from '../hooks/types';
-import ListboxGrid, { ListboxGridProps } from './ListboxGrid/ListboxGrid';
+import ListboxGrid from './ListboxGrid/ListboxGrid';
 import theme from '../theme/theme';
 
-export function render(element: IContainerElement, gridProps: ListboxGridProps) {
+export function render(element: IContainerElement) {
   const root = createRoot(element);
   root.render(
     <ThemeProvider theme={theme}>
-      <ListboxGrid {...gridProps} />
+      <ListboxGrid />
     </ThemeProvider>,
   );
 

--- a/packages/sn-filter-pane/src/store/index.ts
+++ b/packages/sn-filter-pane/src/store/index.ts
@@ -1,27 +1,37 @@
 import { stardust } from '@nebula.js/stardust';
 import createVanilla from 'zustand/vanilla';
-import { IFilterPaneLayout, IUseOptions } from '../hooks/types';
+import create from 'zustand';
+import { IFilterPaneLayout, IListboxResource, IUseOptions } from '../hooks/types';
 import { ISense } from '../types/types';
 
 export interface IStore {
-  app?: EngineAPI.IApp | undefined;
-  setApp?: (app: EngineAPI.IApp) => Function;
+  app?: EngineAPI.IApp;
+  model?: EngineAPI.IGenericObject;
+  isSmallDevice?: (() => void);
+  fpLayout?: IFilterPaneLayout;
+  options: IUseOptions;
+  constraints?: stardust.Constraints;
+  translator?: stardust.Translator;
+  sense?: ISense;
+  embed?: stardust.Embed;
 }
 
-// import create from 'zustand';
-// export const useStore = create((set) => ({
-//   app: undefined,
-//   setApp: (app: EngineAPI.IApp) => set(() => ({ app })),
-// }));
+export const store = createVanilla<IStore>(() => ({
+  app: undefined,
+  model: undefined,
+  isSmallDevice: undefined,
+  fpLayout: undefined,
+  options: {},
+  constraints: undefined,
+  translator: undefined,
+  sense: undefined,
+  embed: undefined,
+}));
 
-export const store = createVanilla(() => ({
-  app: <EngineAPI.IApp | undefined>undefined,
-  model: <EngineAPI.IGenericObject | undefined>undefined,
-  isSmallDevice: <(() => boolean) | undefined>undefined,
-  fpLayout: <IFilterPaneLayout | undefined>undefined,
-  options: <IUseOptions>{},
-  constraints: <stardust.Constraints | undefined>undefined,
-  translator: <stardust.Translator | undefined>undefined,
-  sense: <ISense | undefined>undefined,
-  embed: <stardust.Embed | undefined>undefined,
+interface ResourceState {
+  resources: IListboxResource[];
+}
+
+export const useResourceStore = create<ResourceState>(() => ({
+  resources: [],
 }));


### PR DESCRIPTION
To get updated `resources` when `useRender()` fires and avoid trigger `render()` we save the latest resources in the store.
Fixes #25
