### PR TITLE
feat: import&export properties chart conversion

### DIFF
--- a/packages/sn-filter-pane/src/ext/conversion/index.ts
+++ b/packages/sn-filter-pane/src/ext/conversion/index.ts
@@ -1,23 +1,114 @@
+import extend from 'extend';
 import { ExportFormat, PropTree } from './types';
+import objectConversion from './object-conversion';
+import listObjectUtil from './list-object-util';
 
-export function createImportProperties(exportFormat: ExportFormat, initialProperties: PropTree) {
-  // TODO: add properties for unquarantine
+const MAX_DIMENSIONS = 1000;
+const MIN_DIMENSIONS = 1;
 
-  const propTree: PropTree = {
-    qChildren: [
-      {
-        qProperty: {
-          qInfo: { qType: 'listbox' },
-        },
-      },
-    ],
-    qProperty: {
-      qInfo: {
-        qType: 'filterpane',
-      },
-    },
-  };
-  return propTree;
+export function createImportProperties(exportedFmt: ExportFormat, initialProperties: EngineAPI.IGenericHyperCubeProperties) {
+  const newPropertyTree: PropTree = { qChildren: [], qProperty: {} as EngineAPI.IGenericHyperCubeProperties };
+  let newProperties = {} as EngineAPI.IGenericHyperCubeProperties;
+  const dataGroup = exportedFmt.data[0] as EngineAPI.IGenericHyperCubeProperties;
+  newProperties.qLayoutExclude = { disabled: {} };
+  let i;
+  // for (key in exportedFmt.properties)
+  Object.keys(exportedFmt.properties).forEach((key) => {
+    if (key === 'qLayoutExclude') {
+      if (exportedFmt.properties[key].quarantine) {
+        newProperties.qLayoutExclude.quarantine = extend(true, {}, exportedFmt.properties[key].quarantine);
+      }
+    } else if (initialProperties.hasOwnProperty(key) || objectConversion.isMasterItemProp(key)) {
+      newProperties[key] = exportedFmt.properties[key];
+    } else {
+      newProperties.qLayoutExclude.disabled[key] = exportedFmt.properties[key];
+    }
+  });
+
+  newProperties = extend(true, {}, initialProperties, newProperties);
+
+  for (i = 0; i < dataGroup.dimensions.length; ++i) {
+    if (newPropertyTree.qChildren.length < MAX_DIMENSIONS) {
+      newPropertyTree.qChildren.push({
+        qProperty: listObjectUtil.createDefaultListBox(dataGroup.dimensions[i], dataGroup.dimensions[i].title),
+        qChildren: [],
+      });
+    } else {
+      if (!newProperties.qLayoutExclude) {
+        newProperties.qLayoutExclude = {};
+      }
+      if (!newProperties.qLayoutExclude.qHyperCubeDef) {
+        newProperties.qLayoutExclude.qHyperCubeDef = {};
+      }
+      if (!newProperties.qLayoutExclude.qHyperCubeDef.qDimensions) {
+        newProperties.qLayoutExclude.qHyperCubeDef.qDimensions = [];
+      }
+      newProperties.qLayoutExclude.qHyperCubeDef.qDimensions.push(dataGroup.dimensions[i]);
+    }
+  }
+
+  // filterpane does not support measures, import them as excluded measures
+  if (dataGroup.measures.length) {
+    if (!newProperties.qLayoutExclude.qHyperCubeDef) {
+      newProperties.qLayoutExclude.qHyperCubeDef = {};
+    }
+    if (!newProperties.qLayoutExclude.qHyperCubeDef.qMeasures) {
+      newProperties.qLayoutExclude.qHyperCubeDef.qMeasures = [];
+    }
+    for (i = 0; i < dataGroup.measures.length; ++i) {
+      newProperties.qLayoutExclude.qHyperCubeDef.qMeasures.push(dataGroup.measures[i]);
+    }
+  }
+
+  for (i = 0; i < dataGroup.excludedDimensions.length; ++i) {
+    if (newPropertyTree.qChildren.length < MIN_DIMENSIONS) {
+      newPropertyTree.qChildren.push({
+        qProperty: listObjectUtil.createDefaultListBox(
+          dataGroup.excludedDimensions[i],
+          dataGroup.excludedDimensions[i].title,
+        ),
+        qChildren: [],
+      });
+    } else {
+      if (!newProperties.qLayoutExclude.qHyperCubeDef) {
+        newProperties.qLayoutExclude.qHyperCubeDef = {};
+      }
+      if (!newProperties.qLayoutExclude.qHyperCubeDef.qDimensions) {
+        newProperties.qLayoutExclude.qHyperCubeDef.qDimensions = [];
+      }
+      newProperties.qLayoutExclude.qHyperCubeDef.qDimensions.push(dataGroup.excludedDimensions[i]);
+    }
+  }
+
+  for (i = 0; i < dataGroup.excludedMeasures.length; ++i) {
+    if (!newProperties.qLayoutExclude.qHyperCubeDef) {
+      newProperties.qLayoutExclude.qHyperCubeDef = {};
+    }
+    if (!newProperties.qLayoutExclude.qHyperCubeDef.qMeasures) {
+      newProperties.qLayoutExclude.qHyperCubeDef.qMeasures = [];
+    }
+    newProperties.qLayoutExclude.qHyperCubeDef.qMeasures.push(dataGroup.excludedMeasures[i]);
+  }
+  for (i = 0; i < dataGroup.interColumnSortOrder.length; ++i) {
+    if (newProperties.qLayoutExclude.qHyperCubeDef) {
+      if (!newProperties.qLayoutExclude.qHyperCubeDef.qInterColumnSortOrder) {
+        newProperties.qLayoutExclude.qHyperCubeDef.qInterColumnSortOrder = [];
+      }
+      newProperties.qLayoutExclude.qHyperCubeDef.qInterColumnSortOrder.push(dataGroup.interColumnSortOrder[i]);
+    }
+  }
+
+  // special case for qType and visualization should be copied from the new visualization's default properties.
+  objectConversion.importCommonProperties(newProperties, exportedFmt, initialProperties);
+
+  // special properties for filterpane
+  if (newProperties.showTitles) {
+    newProperties.qLayoutExclude.disabled.previousShowTitles = true;
+    newProperties.showTitles = false;
+  }
+
+  newPropertyTree.qProperty = newProperties;
+  return newPropertyTree;
 }
 
 export function exportProperties(expFormat: ExportFormat) {

--- a/packages/sn-filter-pane/src/ext/conversion/index.ts
+++ b/packages/sn-filter-pane/src/ext/conversion/index.ts
@@ -12,7 +12,6 @@ export function createImportProperties(exportedFmt: ExportFormat, initialPropert
   const dataGroup = exportedFmt.data[0] as EngineAPI.IGenericHyperCubeProperties;
   newProperties.qLayoutExclude = { disabled: {} };
   let i;
-  // for (key in exportedFmt.properties)
   Object.keys(exportedFmt.properties).forEach((key) => {
     if (key === 'qLayoutExclude') {
       if (exportedFmt.properties[key].quarantine) {

--- a/packages/sn-filter-pane/src/ext/conversion/list-object-util.ts
+++ b/packages/sn-filter-pane/src/ext/conversion/list-object-util.ts
@@ -2,6 +2,7 @@ import extend from 'extend';
 
 export default {
   createDefaultListBox(dimensionDef, title) {
+    let newTitle = title;
     const listboxDef = extend(true, {}, dimensionDef);
     let i;
     listboxDef.qShowAlternatives = true;
@@ -9,21 +10,21 @@ export default {
     for (i = 0; i < listboxDef.qDef.qSortCriterias.length; ++i) {
       listboxDef.qDef.qSortCriterias[i].qSortByState = 1;
     }
-    if (!title && dimensionDef.qDef.qLabelExpression) {
-      title = {
+    if (!newTitle && dimensionDef.qDef.qLabelExpression) {
+      newTitle = {
         qStringExpression: {
           qExpr: dimensionDef.qDef.qLabelExpression,
         },
       };
     } else if (
-      !title
+      !newTitle
       && (!dimensionDef.qDef.qFieldLabels
         || !dimensionDef.qDef.qFieldLabels.length
         || dimensionDef.qDef.qFieldLabels[0] === '')
     ) {
-      title = dimensionDef.qDef.qFieldDefs[0];
+      [newTitle] = dimensionDef.qDef.qFieldDefs;
     } else {
-      title = title
+      newTitle = newTitle
         || (dimensionDef.qDef.qFieldLabels && dimensionDef.qDef.qFieldLabels.length
           ? dimensionDef.qDef.qFieldLabels[0]
           : '');
@@ -34,7 +35,7 @@ export default {
         qType: 'listbox',
       },
       qListObjectDef: listboxDef,
-      title,
+      newTitle,
       visualization: 'listbox',
     };
   },

--- a/packages/sn-filter-pane/src/ext/conversion/list-object-util.ts
+++ b/packages/sn-filter-pane/src/ext/conversion/list-object-util.ts
@@ -1,0 +1,41 @@
+import extend from 'extend';
+
+export default {
+  createDefaultListBox(dimensionDef, title) {
+    const listboxDef = extend(true, {}, dimensionDef);
+    let i;
+    listboxDef.qShowAlternatives = true;
+    // listboxDef.qDirectQuerySimplifiedView = directQueryAdaptService.adaptationsEnabled();
+    for (i = 0; i < listboxDef.qDef.qSortCriterias.length; ++i) {
+      listboxDef.qDef.qSortCriterias[i].qSortByState = 1;
+    }
+    if (!title && dimensionDef.qDef.qLabelExpression) {
+      title = {
+        qStringExpression: {
+          qExpr: dimensionDef.qDef.qLabelExpression,
+        },
+      };
+    } else if (
+      !title
+      && (!dimensionDef.qDef.qFieldLabels
+        || !dimensionDef.qDef.qFieldLabels.length
+        || dimensionDef.qDef.qFieldLabels[0] === '')
+    ) {
+      title = dimensionDef.qDef.qFieldDefs[0];
+    } else {
+      title = title
+        || (dimensionDef.qDef.qFieldLabels && dimensionDef.qDef.qFieldLabels.length
+          ? dimensionDef.qDef.qFieldLabels[0]
+          : '');
+    }
+
+    return {
+      qInfo: {
+        qType: 'listbox',
+      },
+      qListObjectDef: listboxDef,
+      title,
+      visualization: 'listbox',
+    };
+  },
+};

--- a/packages/sn-filter-pane/src/ext/conversion/object-conversion.ts
+++ b/packages/sn-filter-pane/src/ext/conversion/object-conversion.ts
@@ -1,12 +1,13 @@
 import { ExportFormat } from './types';
 
 function importCommonProperties(newProperties: EngineAPI.IGenericHyperCubeProperties, exportedFmt: ExportFormat, initialProperties: EngineAPI.IGenericHyperCubeProperties) {
+  const newProps = newProperties;
   if (exportedFmt.properties.qInfo.qType === 'masterobject') {
-    newProperties.qInfo.qType = 'masterobject';
+    newProps.qInfo.qType = 'masterobject';
   } else {
-    newProperties.qInfo.qType = initialProperties.qInfo.qType;
+    newProps.qInfo.qType = initialProperties.qInfo.qType;
   }
-  newProperties.visualization = initialProperties.visualization;
+  newProps.visualization = initialProperties.visualization;
 }
 
 /**

--- a/packages/sn-filter-pane/src/ext/conversion/object-conversion.ts
+++ b/packages/sn-filter-pane/src/ext/conversion/object-conversion.ts
@@ -1,0 +1,24 @@
+import { ExportFormat } from './types';
+
+function importCommonProperties(newProperties: EngineAPI.IGenericHyperCubeProperties, exportedFmt: ExportFormat, initialProperties: EngineAPI.IGenericHyperCubeProperties) {
+  if (exportedFmt.properties.qInfo.qType === 'masterobject') {
+    newProperties.qInfo.qType = 'masterobject';
+  } else {
+    newProperties.qInfo.qType = initialProperties.qInfo.qType;
+  }
+  newProperties.visualization = initialProperties.visualization;
+}
+
+/**
+ * Used to check if a property key is part of the master item information
+ * @param propertyName Name of the key in the properties object
+ * @returns {boolean}
+ */
+function isMasterItemProp(propertyName: string) {
+  return ['qMetaDef', 'descriptionExpression', 'labelExpression'].indexOf(propertyName) !== -1;
+}
+
+export default {
+  importCommonProperties,
+  isMasterItemProp,
+};

--- a/packages/sn-filter-pane/src/ext/conversion/types.ts
+++ b/packages/sn-filter-pane/src/ext/conversion/types.ts
@@ -1,9 +1,9 @@
 export interface ExportFormat {
     data: unknown[];
-    properties: {};
+    properties: EngineAPI.IGenericHyperCubeProperties;
 }
 
 export interface PropTree {
     qChildren: unknown[];
-    qProperty: {};
+    qProperty: EngineAPI.IGenericHyperCubeProperties;
 }

--- a/packages/sn-filter-pane/src/ext/index.ts
+++ b/packages/sn-filter-pane/src/ext/index.ts
@@ -1,7 +1,7 @@
 import pp from './property-panel';
 import { IEnv } from '../types/types';
 import { createImportProperties, exportProperties } from './conversion';
-import { ExportFormat, PropTree } from './conversion/types';
+import { ExportFormat } from './conversion/types';
 
 export default function ext(env: IEnv) {
   return {
@@ -14,7 +14,7 @@ export default function ext(env: IEnv) {
       sharing: false,
       viewData: true,
     },
-    importProperties: (exportFormat:ExportFormat, initialProperties: PropTree) => createImportProperties(exportFormat, initialProperties),
+    importProperties: (exportFormat:ExportFormat, initialProperties: EngineAPI.IGenericHyperCubeProperties) => createImportProperties(exportFormat, initialProperties),
     exportProperties,
   };
 }


### PR DESCRIPTION
Add logic for importing properties and export properties for chart conversion in sn-filter-pane



https://user-images.githubusercontent.com/13185716/215098139-f836d77d-2335-47b8-ae12-2a8dfda0d8b5.mov




