### PR TITLE
feat: signal selection event to sense-client

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,3 +13,7 @@ trim_trailing_whitespace = true
 [*.md]
 insert_final_newline = false
 trim_trailing_whitespace = false
+
+[*.{js,jsx,ts,tsx,json}]
+quote_type = single
+insert_final_newline = true

--- a/packages/sn-filter-pane/src/components/ListboxGrid/ListboxGrid.tsx
+++ b/packages/sn-filter-pane/src/components/ListboxGrid/ListboxGrid.tsx
@@ -6,6 +6,7 @@ import { styled } from '@mui/material/styles';
 // @ts-ignore
 import { ResizableBox } from 'react-resizable';
 import debounce from 'lodash/debounce';
+import { stardust } from '@nebula.js/stardust';
 import getWidthHeight from './get-size';
 import { IListboxResource } from '../../hooks/types';
 import ListboxContainer from '../ListboxContainer';
@@ -21,6 +22,7 @@ import { ColumnItem } from './grid-components/ColumnItem';
 import ConditionalWrapper from './ConditionalWrapper';
 import { store, useResourceStore } from '../../store';
 import { ListboxPopoverContainer } from '../ListboxPopoverContainer';
+import useHandleActive, { ActiveOnly } from './use-handle-active';
 
 // TODO: Remove
 const Resizable = styled(ResizableBox)(() => ({
@@ -28,7 +30,7 @@ const Resizable = styled(ResizableBox)(() => ({
 }));
 
 function ListboxGrid() {
-  const { sense } = store.getState();
+  const { sense, selections } = store.getState();
   const resources = useResourceStore((state) => state.resources);
 
   const gridRef = useRef<HTMLDivElement>();
@@ -54,6 +56,7 @@ function ListboxGrid() {
     }
   }, [resources]);
 
+  const handleActive = useHandleActive(isInSense, selections as stardust.ObjectSelections & ActiveOnly);
   const dHandleResize = debounce(handleResize, isInSense ? 0 : 50);
 
   // TODO: Remove Resizable, only for developing purposes
@@ -80,6 +83,8 @@ function ListboxGrid() {
                         ? <ListboxContainer
                           layout={item.layout}
                           borderBottom={(column.items?.length === j + 1) || !item.fullyExpanded}
+                          disableSearch={item.cardinal <= 3}
+                          handleActive={handleActive}
                         ></ListboxContainer>
                         : <ListboxPopoverContainer resources={[item]} />
                       }

--- a/packages/sn-filter-pane/src/components/ListboxGrid/__tests__/distribute-resources.spec.ts
+++ b/packages/sn-filter-pane/src/components/ListboxGrid/__tests__/distribute-resources.spec.ts
@@ -190,10 +190,10 @@ describe('Listbox grid layout', () => {
       const result = calculateExpandPriority(mergedColumns, size);
       expect(result[0].items?.[0].fullyExpanded).toBe(true);
       expect(result[0].items?.[0].expand).toBe(true);
-      expect(result[0].items?.[0].height).toBe('906px');
+      expect(result[0].items?.[0].height).toBe('802px');
       expect(result[0].items?.[1].fullyExpanded).toBe(false);
       expect(result[0].items?.[1].expand).toBe(true);
-      expect(result[0].items?.[1].height).toBe('361px');
+      expect(result[0].items?.[1].height).toBe('465px');
     });
   });
 });

--- a/packages/sn-filter-pane/src/components/ListboxGrid/distribute-resources.ts
+++ b/packages/sn-filter-pane/src/components/ListboxGrid/distribute-resources.ts
@@ -11,7 +11,7 @@ const COLUMN_MIN_WIDTH = 160;
 const COLUMN_SPACING = 16;
 const EXPANDED_HEADER_HEIGHT = 48;
 
-const getExpandedRowHeight = (dense: boolean) => (dense ? 20 : 33);
+const getExpandedRowHeight = (dense: boolean) => (dense ? 20 : 29);
 
 const sm = () => {
   const { isSmallDevice } = store.getState();
@@ -45,7 +45,8 @@ const getDimensionCardinal = (item: IListboxResource) => item.layout.qListObject
 const getHeightOfExpanded = (
   dimensionCardinal: number,
   dense: boolean,
-) => dimensionCardinal * getExpandedRowHeight(dense) + EXPANDED_HEADER_HEIGHT;
+  hiddenHeader: boolean,
+) => dimensionCardinal * getExpandedRowHeight(dense) + (hiddenHeader ? 0 : EXPANDED_HEADER_HEIGHT);
 
 const doesAllFit = (
   itemsPerColumn: number,
@@ -140,8 +141,8 @@ export const mergeColumnsAndResources = (columns: IColumn[], resources: IListbox
 };
 
 const setFullyExpanded = (item: IListboxResource) => {
-  if (parseFloat(item.height) >= getHeightOfExpanded(item.cardinal, item.dense)) {
-    item.height = `${getHeightOfExpanded(item.cardinal, item.dense)}px`;
+  if (parseFloat(item.height) >= getHeightOfExpanded(item.cardinal, item.dense, item.hiddenHeader)) {
+    item.height = `${getHeightOfExpanded(item.cardinal, item.dense, item.hiddenHeader)}px`;
     item.fullyExpanded = true;
   }
 };
@@ -155,7 +156,7 @@ const expandOne = (sortedItems: IListboxResource[] | undefined, leftOverHeight: 
   for (i = 0; i < sortedItems.length; i++) {
     item = sortedItems[i];
     if (item.cardinal && !item.expand) {
-      expandedHeight = getHeightOfExpanded(item.cardinal, item.dense);
+      expandedHeight = getHeightOfExpanded(item.cardinal, item.dense, item.hiddenHeader);
       if (leftOverHeight > expandedHeight) {
         item.expand = true;
         item.height = `${expandedHeight}px`;
@@ -197,7 +198,7 @@ export const calculateExpandPriority = (columns: IColumn[], size: ISize) => {
         // Calculate total expanded height again as items might have been expanded before calculateExpandPriority
         totalExpandedHeight = 0;
         expandedItems?.forEach((item) => {
-          totalExpandedHeight += getHeightOfExpanded(item.cardinal, item.dense) + ITEM_SPACING;
+          totalExpandedHeight += getHeightOfExpanded(item.cardinal, item.dense, item.hiddenHeader) + ITEM_SPACING;
         });
         leftOverHeight = size.height - getHeightOf((column?.itemCount ?? 0) - (expandedItems?.length ?? 0)) - totalExpandedHeight;
       }
@@ -234,5 +235,6 @@ export const setDefaultValues = (resources: IListboxResource[]) => resources.map
   resource.height = 'calc(100% - 2px)';
   resource.fullyExpanded = false;
   resource.dense = resource.layout.layoutOptions?.dense ?? false;
+  resource.hiddenHeader = resource.layout.toolbar !== undefined ? !resource.layout.toolbar : false;
   return resource;
 });

--- a/packages/sn-filter-pane/src/components/ListboxGrid/use-handle-active.ts
+++ b/packages/sn-filter-pane/src/components/ListboxGrid/use-handle-active.ts
@@ -1,0 +1,54 @@
+import { stardust } from '@nebula.js/stardust';
+import { useEffect, useState } from 'react';
+
+export interface ActiveOnly {
+  begin?: (path: string | null, activeOnly: boolean) => Promise<undefined>;
+  confirm?: (activeOnly: boolean) => Promise<undefined>;
+}
+
+export default function useHandleActive(
+  isInSense: boolean,
+  selections?: stardust.ObjectSelections & ActiveOnly,
+) {
+  const [selectionStates, setSelectionStates] = useState<
+    { id: string; active: boolean }[] | []
+  >([]);
+  const [inSelection, setInSelection] = useState(false);
+
+  useEffect(() => {
+    const alreadyInSelection = inSelection;
+    const newInSelection = !!selectionStates.find((state) => state.active);
+    setInSelection(newInSelection);
+    if (newInSelection && !alreadyInSelection && isInSense) {
+      selections?.begin(null, true);
+    } else if (!inSelection && isInSense) {
+      selections?.confirm(true);
+    }
+  }, [selectionStates]);
+
+  const updateActiveSelectionState = (id: string, active: boolean) => {
+    setSelectionStates((currentSelectionStates) => {
+      const newSelectionStates = [...currentSelectionStates];
+      const stateToUpdate = newSelectionStates.find((state) => state.id === id);
+      if (stateToUpdate) {
+        stateToUpdate.active = active;
+      } else {
+        newSelectionStates.push({ id, active });
+      }
+      return newSelectionStates;
+    });
+  };
+
+  const handleActive = (id: string, active: boolean) => {
+    if (!active) {
+      // If user is in selection and starts selecting in another Listbox, delay deactivate event from the first Listbox
+      setTimeout(() => {
+        updateActiveSelectionState(id, active);
+      }, 200);
+    } else {
+      updateActiveSelectionState(id, active);
+    }
+  };
+
+  return handleActive;
+}

--- a/packages/sn-filter-pane/src/ext/property-panel/data/index.ts
+++ b/packages/sn-filter-pane/src/ext/property-panel/data/index.ts
@@ -55,6 +55,13 @@ export default function data(env: IEnv) {
         expression: 'optional',
         translation: 'Common.Title',
       },
+      showTitle: {
+        ref: 'toolbar',
+        component: 'checkbox',
+        type: 'boolean',
+        translation: 'properties.filterpane.showTitle',
+        defaultValue: true,
+      },
       frequencyCountMode: {
         ref: 'qListObjectDef.qFrequencyMode',
         convertFunctions: {

--- a/packages/sn-filter-pane/src/hooks/types/index.d.ts
+++ b/packages/sn-filter-pane/src/hooks/types/index.d.ts
@@ -51,6 +51,7 @@ export interface IListboxResource {
   responsiveMode: string;
   fullyExpanded: boolean;
   dense: boolean;
+  hiddenHeader: boolean;
 }
 
 export type ListboxResourcesArr = array & IListboxResource[];

--- a/packages/sn-filter-pane/src/hooks/use-setup.ts
+++ b/packages/sn-filter-pane/src/hooks/use-setup.ts
@@ -1,5 +1,5 @@
 import {
-  useEmbed, useApp, useLayout, useModel, useOptions, useConstraints, useTranslator, useTheme,
+  useEmbed, useApp, useLayout, useModel, useOptions, useConstraints, useTranslator, useTheme, useSelections,
 } from '@nebula.js/stardust';
 import { store } from '../store';
 import { IEnv } from '../types/types';
@@ -14,6 +14,7 @@ export default function useSetup({ sense }: IEnv) {
   const model = useModel();
   const embed = useEmbed();
   const stardustTheme = useTheme();
+  const selections = useSelections();
 
   store.setState({
     app,
@@ -25,5 +26,6 @@ export default function useSetup({ sense }: IEnv) {
     translator,
     embed,
     stardustTheme,
+    selections,
   });
 }

--- a/packages/sn-filter-pane/src/store/index.ts
+++ b/packages/sn-filter-pane/src/store/index.ts
@@ -15,6 +15,7 @@ export interface IStore {
   sense?: ISense;
   embed?: stardust.Embed;
   stardustTheme?: stardust.Theme;
+  selections?: stardust.ObjectSelections;
 }
 
 export const store = createVanilla<IStore>(() => ({

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -6,7 +6,8 @@ export interface IListLayout extends EngineAPI.IGenericListLayout {
   },
   layoutOptions?: {
     dense: boolean,
-  }
+  },
+  toolbar?: boolean,
 }
 
 // Missing properties in EngineAPI.IGenericListProperties are added in this interface until


### PR DESCRIPTION
*Propagate selection event from Listbox to sense-client (By keeping track of selection states for listboxes). To show hide context menu in sense-client.
*Update size of Listbox
*Disable search in Listbox if it contains 3 items or less
*Update property-panel to show/hide title(toolbar) in Listbox. Take hidden title in account in `distribue-resources.ts`

![Kapture 2023-02-15 at 12 10 51](https://user-images.githubusercontent.com/99665802/219013105-cc433ee6-e8a9-4a6f-936d-df1261bac551.gif)
![Kapture 2023-02-15 at 12 16 50](https://user-images.githubusercontent.com/99665802/219013109-b20fd1b1-ce1c-4671-a30d-9b4f2e7014b1.gif)
