### PR TITLE
fix: set minimum number of dimensions to 1

### DIFF
--- a/packages/sn-filter-pane/src/qae/data.ts
+++ b/packages/sn-filter-pane/src/qae/data.ts
@@ -18,7 +18,7 @@ export default function getData(env: IEnv) {
         path: '/qChildListDef/qDef/qListObjectDef',
         measures: { min: 0, max: 0 },
         dimensions: {
-          min: 0,
+          min: 1,
           max: 1000,
           add(dimension: EngineAPI.INxDimension & INxDimensionMissing, data: EngineAPI.IGenericObjectProperties /* , handler */) {
             const { model: filterPaneModel } = store.getState();


### PR DESCRIPTION
To fix https://github.com/qlik-oss/sn-list-objects/issues/48 by setting the minimum number of dimensions to 1 to make it the same to the old filter pane.