### PR TITLE
fix: remove getProperties request on selection

### DIFF
--- a/packages/sn-filter-pane/src/hooks/listbox/get-listbox-resources.ts
+++ b/packages/sn-filter-pane/src/hooks/listbox/get-listbox-resources.ts
@@ -3,13 +3,11 @@ import { IFilterPaneLayout, ListboxResourcesArr } from '../types';
 async function getListboxResourcesFromIds(app: EngineAPI.IApp, ids: string[]): Promise<ListboxResourcesArr> {
   const models = await Promise.all(ids.map((id) => app.getObject(id)));
   const layouts = await Promise.all(models.map((model) => model.getLayout() as unknown as EngineAPI.IGenericListLayout));
-  const properties = await Promise.all(models.map((model) => model.getProperties()));
 
   return ids.map((id: string, index: number) => ({
     id,
     model: models[index],
     layout: layouts[index],
-    properties: properties[index],
   }));
 }
 

--- a/packages/sn-filter-pane/src/hooks/types/index.d.ts
+++ b/packages/sn-filter-pane/src/hooks/types/index.d.ts
@@ -44,7 +44,6 @@ export interface IListboxResource {
   id: string;
   model: GenericObjectModel;
   layout: IListLayout;
-  properties?: EngineAPI.IGenericObjectProperties;
   height: string;
   expand: boolean;
   cardinal: number;

--- a/packages/sn-filter-pane/src/hooks/types/index.d.ts
+++ b/packages/sn-filter-pane/src/hooks/types/index.d.ts
@@ -44,7 +44,7 @@ export interface IListboxResource {
   id: string;
   model: GenericObjectModel;
   layout: IListLayout;
-  properties: EngineAPI.IGenericObjectProperties;
+  properties?: EngineAPI.IGenericObjectProperties;
   height: string;
   expand: boolean;
   cardinal: number;


### PR DESCRIPTION
On selection, there is no need to send getProperties to engine. This will improve the performance of render a listbox on selection.