### PR TITLE
fix: fix drop filed/measure to a filter pane

### DIFF
--- a/packages/sn-filter-pane/src/ext/index.ts
+++ b/packages/sn-filter-pane/src/ext/index.ts
@@ -16,14 +16,14 @@ export default function ext(env: IEnv) {
     },
     importProperties: (exportFormat:ExportFormat, initialProperties: EngineAPI.IGenericHyperCubeProperties) => createImportProperties(exportFormat, initialProperties),
     exportProperties,
-    getDropFieldOptions(builder, propertyHandler, model: EngineAPI.IGenericObject/* , showMenu, object */) {
+    getDropFieldOptions(builder:any, propertyHandler:any, model: EngineAPI.IGenericObject/* , showMenu, object */) {
       if (propertyHandler.getDimensions().length < propertyHandler.maxDimensions()) {
         propertyHandler.setModel(model);
         builder.Add(model, propertyHandler);
         builder.menu?.items?.[0]?.select();
       }
     },
-    getDropMeasureOptions(builder, propertyHandler, model: EngineAPI.IGenericObject, showMenu: () => void) {
+    getDropMeasureOptions(builder:any, propertyHandler:any, model: EngineAPI.IGenericObject, showMenu: () => void) {
       showMenu();
     },
   };

--- a/packages/sn-filter-pane/src/ext/index.ts
+++ b/packages/sn-filter-pane/src/ext/index.ts
@@ -16,5 +16,15 @@ export default function ext(env: IEnv) {
     },
     importProperties: (exportFormat:ExportFormat, initialProperties: EngineAPI.IGenericHyperCubeProperties) => createImportProperties(exportFormat, initialProperties),
     exportProperties,
+    getDropFieldOptions(builder, propertyHandler, model: EngineAPI.IGenericObject/* , showMenu, object */) {
+      if (propertyHandler.getDimensions().length < propertyHandler.maxDimensions()) {
+        propertyHandler.setModel(model);
+        builder.Add(model, propertyHandler);
+        builder.menu?.items?.[0]?.select();
+      }
+    },
+    getDropMeasureOptions(builder, propertyHandler, model: EngineAPI.IGenericObject, showMenu: () => void) {
+      showMenu();
+    },
   };
 }


### PR DESCRIPTION
This is to fix https://github.com/qlik-oss/sn-list-objects/issues/132 and https://github.com/qlik-oss/sn-list-objects/issues/131 by adding getDropFieldOptions and getDropMeasureOptions to sn-filter-pane.