### PR TITLE
fix: update frequency max on relating change

### DIFF
--- a/packages/sn-filter-pane/src/ext/property-panel/data/data-panel/__test__/update-frequency-max.spec.ts
+++ b/packages/sn-filter-pane/src/ext/property-panel/data/data-panel/__test__/update-frequency-max.spec.ts
@@ -1,0 +1,69 @@
+import updateForFrequencyMax from '../update-frequency-max';
+
+describe('updateForFrequencyMax', () => {
+  let itemData: any;
+
+  it('should update correctly when histogram = false', () => {
+    itemData = { histogram: false };
+    updateForFrequencyMax(itemData);
+    expect(itemData).toEqual({ histogram: false, frequencyMax: null });
+  });
+
+  it('should update correctly when histogram = false and frequencyMax = something', () => {
+    itemData = { histogram: false, frequencyMax: 'abc' };
+    updateForFrequencyMax(itemData);
+    expect(itemData).toEqual({ histogram: false, frequencyMax: null });
+  });
+
+  it('should update correctly when histogram = true and qFrequencyMode = N', () => {
+    itemData = { histogram: true, qListObjectDef: { qFrequencyMode: 'N', qDef: { } } };
+    updateForFrequencyMax(itemData);
+    expect(itemData.qListObjectDef.qFrequencyMode).toEqual('V');
+    const exp = undefined;
+    expect(itemData.frequencyMax).toEqual({ qValueExpression: `Max(AGGR(Count([${exp}]), [${exp}]))` });
+  });
+
+  it('should update correctly when histogram = true and qFrequencyMode = P', () => {
+    itemData = { histogram: true, qListObjectDef: { qFrequencyMode: 'P', qDef: { } } };
+    updateForFrequencyMax(itemData);
+    expect(itemData.qListObjectDef.qFrequencyMode).toEqual('P');
+    expect(itemData.frequencyMax).toEqual(null);
+  });
+
+  it('should update correctly when histogram = true and qFrequencyMode = R', () => {
+    itemData = { histogram: true, qListObjectDef: { qFrequencyMode: 'R', qDef: { } } };
+    updateForFrequencyMax(itemData);
+    expect(itemData.qListObjectDef.qFrequencyMode).toEqual('R');
+    expect(itemData.frequencyMax).toEqual(null);
+  });
+
+  it('should update correctly when histogram = true and qFrequencyMode = V', () => {
+    itemData = { histogram: true, qListObjectDef: { qFrequencyMode: 'V', qDef: { } } };
+    updateForFrequencyMax(itemData);
+    expect(itemData.qListObjectDef.qFrequencyMode).toEqual('V');
+    const exp = undefined;
+    expect(itemData.frequencyMax).toEqual({ qValueExpression: `Max(AGGR(Count([${exp}]), [${exp}]))` });
+  });
+
+  it('should update correctly when histogram = true, qFrequencyMode = V, qFieldDefs: ["Dim1"]', () => {
+    itemData = { histogram: true, qListObjectDef: { qFrequencyMode: 'V', qDef: { qFieldDefs: ['Dim1'] } } };
+    updateForFrequencyMax(itemData);
+    expect(itemData.qListObjectDef.qFrequencyMode).toEqual('V');
+    const exp = 'Dim1';
+    expect(itemData.frequencyMax).toEqual({ qValueExpression: `Max(AGGR(Count([${exp}]), [${exp}]))` });
+  });
+
+  it('should update correctly when histogram = true, qFrequencyMode = V, qFieldDefs: ["[Dim1]"]', () => {
+    itemData = { histogram: true, qListObjectDef: { qFrequencyMode: 'V', qDef: { qFieldDefs: ['[Dim1]'] } } };
+    updateForFrequencyMax(itemData);
+    expect(itemData.qListObjectDef.qFrequencyMode).toEqual('V');
+    expect(itemData.frequencyMax).toEqual({ qValueExpression: 'Max(AGGR(Count([[Dim1]]]), [[Dim1]]]))' });
+  });
+
+  it('should update correctly when histogram = true, qFrequencyMode = V, qFieldDefs: ["=[Dim1]"]', () => {
+    itemData = { histogram: true, qListObjectDef: { qFrequencyMode: 'V', qDef: { qFieldDefs: ['=[Dim1]'] } } };
+    updateForFrequencyMax(itemData);
+    expect(itemData.qListObjectDef.qFrequencyMode).toEqual('V');
+    expect(itemData.frequencyMax).toEqual({ qValueExpression: 'Max(AGGR(Count([=[Dim1]]]), [=[Dim1]]]))' });
+  });
+});

--- a/packages/sn-filter-pane/src/ext/property-panel/data/data-panel/index.ts
+++ b/packages/sn-filter-pane/src/ext/property-panel/data/data-panel/index.ts
@@ -1,7 +1,7 @@
 import { IEnv } from '../../../../types/types';
 import { IGenericListPropertiesMissing } from '../../../../hooks/types';
 import getPresentation from './presentation';
-import updateFrequencyMax from './update-frequency-max';
+import updateForFrequencyMax from './update-frequency-max';
 
 const autoSortCriterias: EngineAPI.ISortCriteria = {
   qSortByState: 1 as EngineAPI.TypeSortDirection,
@@ -42,7 +42,7 @@ export default function getDataPanelItems(env: IEnv) {
           def.qFieldLabels = [];
         }
         [def.qFieldLabels[0]] = def.qFieldDefs ?? [];
-        updateFrequencyMax(itemData);
+        updateForFrequencyMax(itemData);
       },
     },
     title: {

--- a/packages/sn-filter-pane/src/ext/property-panel/data/data-panel/index.ts
+++ b/packages/sn-filter-pane/src/ext/property-panel/data/data-panel/index.ts
@@ -1,6 +1,7 @@
 import { IEnv } from '../../../../types/types';
 import { IGenericListPropertiesMissing } from '../../../../hooks/types';
 import getPresentation from './presentation';
+import updateFrequencyMax from './update-frequency-max';
 
 const autoSortCriterias: EngineAPI.ISortCriteria = {
   qSortByState: 1 as EngineAPI.TypeSortDirection,
@@ -35,12 +36,13 @@ export default function getDataPanelItems(env: IEnv) {
       show(itemData: EngineAPI.IGenericListProperties) {
         return !itemData.qListObjectDef.qLibraryId;
       },
-      change(itemData: EngineAPI.IGenericListProperties) {
+      change(itemData: EngineAPI.IGenericListProperties & IGenericListPropertiesMissing) {
         const def = itemData.qListObjectDef.qDef;
         if (!def.qFieldLabels) {
           def.qFieldLabels = [];
         }
         [def.qFieldLabels[0]] = def.qFieldDefs ?? [];
+        updateFrequencyMax(itemData);
       },
     },
     title: {

--- a/packages/sn-filter-pane/src/ext/property-panel/data/data-panel/presentation/index.ts
+++ b/packages/sn-filter-pane/src/ext/property-panel/data/data-panel/presentation/index.ts
@@ -3,8 +3,11 @@ import { IGenericListPropertiesMissing } from '../../../../../../../../types/glo
 import textAlignItems from '../../text-align-items';
 import { IEnv } from '../../../../../types/types';
 import frequencies from '../../../constants';
+import updateFrequencyMax from '../update-frequency-max';
 
 const DEFAULT_LAYOUT_ORDER = 'column';
+
+const change = updateFrequencyMax;
 
 export default function getPresentation(env: IEnv) {
   const { translator } = env;
@@ -32,13 +35,7 @@ export default function getPresentation(env: IEnv) {
         component: 'checkbox',
         translation: 'properties.filterpane.showHistogram',
         defaultValue: false,
-        change(itemData: EngineAPI.IGenericListProperties & IGenericListPropertiesMissing) {
-          if (itemData.histogram && itemData.qListObjectDef.qFrequencyMode === frequencies.FREQUENCY_NONE) {
-            itemData.qListObjectDef.qFrequencyMode = frequencies.FREQUENCY_VALUE;
-          }
-          const [qDef] = itemData.qListObjectDef.qDef.qFieldDefs ?? [];
-          itemData.frequencyMax = itemData.histogram ? { qValueExpression: `Max(AGGR(Count([${qDef}]), [${qDef}]))` } : null;
-        },
+        change,
       },
       frequencyCountModeGroup: {
         translation: 'properties.frequencyCountMode',
@@ -68,6 +65,7 @@ export default function getPresentation(env: IEnv) {
                 translation: 'properties.frequencyCountAsPercent',
               },
             ],
+            change,
             convertFunctions: {
               get(
                 getter: () => EngineAPI.FrequencyModeType,

--- a/packages/sn-filter-pane/src/ext/property-panel/data/data-panel/presentation/index.ts
+++ b/packages/sn-filter-pane/src/ext/property-panel/data/data-panel/presentation/index.ts
@@ -3,11 +3,11 @@ import { IGenericListPropertiesMissing } from '../../../../../../../../types/glo
 import textAlignItems from '../../text-align-items';
 import { IEnv } from '../../../../../types/types';
 import frequencies from '../../../constants';
-import updateFrequencyMax from '../update-frequency-max';
+import updateForFrequencyMax from '../update-frequency-max';
 
 const DEFAULT_LAYOUT_ORDER = 'column';
 
-const change = updateFrequencyMax;
+const change = updateForFrequencyMax;
 
 export default function getPresentation(env: IEnv) {
   const { translator } = env;

--- a/packages/sn-filter-pane/src/ext/property-panel/data/data-panel/update-frequency-max.ts
+++ b/packages/sn-filter-pane/src/ext/property-panel/data/data-panel/update-frequency-max.ts
@@ -9,13 +9,17 @@ const escapeField = (field: string) => {
   return `${field.replace(/\]/g, ']]')}`;
 };
 
-const change = (itemData: EngineAPI.IGenericListProperties & IGenericListPropertiesMissing) => {
+const updateForFrequencyMax = (itemData: EngineAPI.IGenericListProperties & IGenericListPropertiesMissing) => {
   if (itemData.histogram && itemData.qListObjectDef.qFrequencyMode === frequencies.FREQUENCY_NONE) {
     itemData.qListObjectDef.qFrequencyMode = frequencies.FREQUENCY_VALUE;
   }
-  const [qDef] = itemData.qListObjectDef.qDef.qFieldDefs ?? [];
-  const exp = escapeField(qDef as string);
-  itemData.frequencyMax = itemData.histogram && itemData.qListObjectDef.qFrequencyMode === frequencies.FREQUENCY_VALUE ? { qValueExpression: `Max(AGGR(Count([${exp}]), [${exp}]))` } : null;
+  if (!itemData.histogram || itemData.qListObjectDef.qFrequencyMode !== frequencies.FREQUENCY_VALUE) {
+    itemData.frequencyMax = null;
+  } else {
+    const [qDef] = itemData.qListObjectDef.qDef.qFieldDefs ?? [];
+    const exp = escapeField(qDef as string);
+    itemData.frequencyMax = { qValueExpression: `Max(AGGR(Count([${exp}]), [${exp}]))` };
+  }
 };
 
-export default change;
+export default updateForFrequencyMax;

--- a/packages/sn-filter-pane/src/ext/property-panel/data/data-panel/update-frequency-max.ts
+++ b/packages/sn-filter-pane/src/ext/property-panel/data/data-panel/update-frequency-max.ts
@@ -1,0 +1,21 @@
+/* eslint-disable no-param-reassign */
+import { IGenericListPropertiesMissing } from '../../../../../../../types/global';
+import frequencies from '../../constants';
+
+const escapeField = (field: string) => {
+  if (!field || field === ']') {
+    return field;
+  }
+  return `${field.replace(/\]/g, ']]')}`;
+};
+
+const change = (itemData: EngineAPI.IGenericListProperties & IGenericListPropertiesMissing) => {
+  if (itemData.histogram && itemData.qListObjectDef.qFrequencyMode === frequencies.FREQUENCY_NONE) {
+    itemData.qListObjectDef.qFrequencyMode = frequencies.FREQUENCY_VALUE;
+  }
+  const [qDef] = itemData.qListObjectDef.qDef.qFieldDefs ?? [];
+  const exp = escapeField(qDef as string);
+  itemData.frequencyMax = itemData.histogram && itemData.qListObjectDef.qFrequencyMode === frequencies.FREQUENCY_VALUE ? { qValueExpression: `Max(AGGR(Count([${exp}]), [${exp}]))` } : null;
+};
+
+export default change;


### PR DESCRIPTION
This PR is to fix frequency max in case of a calculated dimension which uses ]. It also trigger an update for frequency max on relating change like a field being changed or histogram option being changed or frequency option being changed.