### PR TITLE
chore: enable systemjs builds

### DIFF
--- a/packages/sn-filter-pane/package.json
+++ b/packages/sn-filter-pane/package.json
@@ -22,6 +22,7 @@
     "node": ">=8"
   },
   "main": "dist/sn-filter-pane.js",
+  "systemjs": "dist/sn-filter-pane.systemjs.js",
   "jest": {
     "testEnvironment": "jsdom"
   },

--- a/packages/sn-listbox/package.json
+++ b/packages/sn-listbox/package.json
@@ -22,6 +22,7 @@
     "node": ">=8"
   },
   "main": "dist/sn-listbox.js",
+  "systemjs": "dist/sn-listbox.systemjs.js",
   "scripts": {
     "start": "nebula serve --type sn-listbox --mode development",
     "build": "node ./scripts/build.js --ext --core core",


### PR DESCRIPTION
Add the systemjs flags to package.json to prepare for qmfe.

Note: this seems to increase the buildtime quite a lot for the filterpane, from an already high level. In theory it can double the time, but it is worse, not exactly sure why.