### PR TITLE
fix: close popover when selections confirmed or cancelled

### DIFF
--- a/packages/sn-filter-pane/src/components/ListboxContainer.tsx
+++ b/packages/sn-filter-pane/src/components/ListboxContainer.tsx
@@ -11,7 +11,7 @@ interface ListboxContainerProps {
   disableSearch?: boolean;
   handleActive?: (id: string, active: boolean) => void;
   stores: IStores;
-  closePopover?: (close: boolean) => void;
+  closePopover?: () => void;
 }
 
 const ListboxContainer = ({
@@ -70,7 +70,7 @@ const ListboxContainer = ({
     const handleActivate = () => handleActive?.(layout.qInfo.qId, true);
     const handleDeactivate = () => {
       handleActive?.(layout.qInfo.qId, false);
-      closePopover?.(true);
+      closePopover?.();
     };
     listboxInstance.on?.('selectionActivated', handleActivate);
     listboxInstance.on?.('selectionDeactivated', handleDeactivate);

--- a/packages/sn-filter-pane/src/components/ListboxContainer.tsx
+++ b/packages/sn-filter-pane/src/components/ListboxContainer.tsx
@@ -11,10 +11,11 @@ interface ListboxContainerProps {
   disableSearch?: boolean;
   handleActive?: (id: string, active: boolean) => void;
   stores: IStores;
+  closePopover?: (close: boolean) => void;
 }
 
 const ListboxContainer = ({
-  layout, borderBottom, disableSearch = false, handleActive, stores,
+  layout, borderBottom, disableSearch = false, handleActive, stores, closePopover,
 }: ListboxContainerProps) => {
   const [listboxInstance, setListboxInstance] = useState<stardust.FieldInstance>();
   const elRef = useRef<HTMLElement>();
@@ -67,7 +68,10 @@ const ListboxContainer = ({
       return undefined;
     }
     const handleActivate = () => handleActive?.(layout.qInfo.qId, true);
-    const handleDeactivate = () => handleActive?.(layout.qInfo.qId, false);
+    const handleDeactivate = () => {
+      handleActive?.(layout.qInfo.qId, false);
+      closePopover?.(true);
+    };
     listboxInstance.on?.('selectionActivated', handleActivate);
     listboxInstance.on?.('selectionDeactivated', handleDeactivate);
 

--- a/packages/sn-filter-pane/src/components/ListboxPopoverContainer.tsx
+++ b/packages/sn-filter-pane/src/components/ListboxPopoverContainer.tsx
@@ -62,10 +62,8 @@ export const ListboxPopoverContainer = ({ resources, stores }: FoldedPopoverProp
     }, transitionDuration);
   };
 
-  const closePopover = (close : boolean) => {
-    if (close) {
-      handleClose();
-    }
+  const closePopover = () => {
+    handleClose();
   };
 
   const isSingle = resources.length === 1;

--- a/packages/sn-filter-pane/src/components/ListboxPopoverContainer.tsx
+++ b/packages/sn-filter-pane/src/components/ListboxPopoverContainer.tsx
@@ -62,6 +62,12 @@ export const ListboxPopoverContainer = ({ resources, stores }: FoldedPopoverProp
     }, transitionDuration);
   };
 
+  const closePopover = (close : boolean) => {
+    if (close) {
+      handleClose();
+    }
+  };
+
   const isSingle = resources.length === 1;
 
   const selectResource = ({ resource }: FoldedListboxClickEvent) => {
@@ -92,7 +98,7 @@ export const ListboxPopoverContainer = ({ resources, stores }: FoldedPopoverProp
         marginThreshold= {isSmallDevice ? 0 : 16}
       >
         {(selectedResource || isSingle)
-          ? <ListboxContainer layout={selectedResource?.layout ?? resources[0].layout} stores={stores} />
+          ? <ListboxContainer layout={selectedResource?.layout ?? resources[0].layout} stores={stores} closePopover={ closePopover } />
           : <Grid container direction='column' spacing={1} padding='8px'>
             {!!resources?.length && resources?.map((resource) => (
               <Grid item key={resource.id}>


### PR DESCRIPTION
Popover is also closed with Esc and Enter corresponding to Cancel and Confirm selections respectively. Fixes : https://github.com/qlik-oss/sn-list-objects/issues/160

https://user-images.githubusercontent.com/30860406/226853272-3ad7bb62-42d3-44d0-8bc7-7f24bc9551ea.mp4