### PR TITLE
fix: avoid adding copyCellValue items twice

### DIFF
--- a/packages/sn-filter-pane/src/hooks/use-context-menu.ts
+++ b/packages/sn-filter-pane/src/hooks/use-context-menu.ts
@@ -43,10 +43,15 @@ export default function useContextMenu() {
     if (!text) {
       return;
     }
+    const tid = 'copy-cell-context-item';
+    // @ts-ignore
+    if (menu.items.filter((item) => item.tid === tid).length) {
+      return;
+    }
     menu.addItem({
       translation: 'contextMenu.copyCellValue',
       icon: 'lui-icon lui-icon--copy',
-      tid: 'copy-cell-context-item',
+      tid,
       select: async () => {
         copyToClipboard(text);
       },


### PR DESCRIPTION
To fix https://github.com/qlik-oss/sn-list-objects/issues/187 by checking if the item Copy cell value is already added or not.