### PR TITLE
feat(sn-filter-pane): Support Direct Query

### DIFF
--- a/packages/sn-filter-pane/src/components/ListboxContainer.tsx
+++ b/packages/sn-filter-pane/src/components/ListboxContainer.tsx
@@ -1,9 +1,12 @@
 import React, { useEffect, useRef, useState } from 'react';
+import extend from 'extend';
 import { Box } from '@mui/material';
 import { stardust } from '@nebula.js/stardust';
 import { IListLayout } from '../hooks/types';
 import type { IStores } from '../store';
 import uid from '../utils/uid';
+import { IEnv } from '../types/types';
+import useDirectQuery from '../hooks/direct-query/use-direct-query';
 
 interface ListboxContainerProps {
   layout: IListLayout;
@@ -28,9 +31,16 @@ const ListboxContainer = ({
     constraints,
     options,
     renderTracker,
-    sense,
+    env,
     stardustTheme,
+    directQueryEnabled,
   } = stores.store.getState();
+
+  const { sense } = env as IEnv;
+
+  const dqOptionsOverrides = useDirectQuery({
+    directQueryEnabled, layout, sessionModel: model, constraints,
+  });
 
   const showBorder = !sense || inSelection || stardustTheme?.getStyle('', '', '_cards');
 
@@ -51,14 +61,14 @@ const ListboxContainer = ({
     }
 
     const allowSelect = !constraints?.select && !constraints?.active;
-    const listboxOptions = {
+    const listboxOptions = extend(true, {
       __DO_NOT_USE__: {
         selectDisabled: () => !allowSelect, // can we hook this into the selections api?
       },
       direction: options?.direction,
       search: disableSearch ? false : ('toggle' as stardust.SearchMode),
       isPopover,
-    };
+    }, dqOptionsOverrides || {});
 
     // @ts-ignore
     listboxInstance.mount(elRef.current, listboxOptions).then(() => {
@@ -92,16 +102,14 @@ const ListboxContainer = ({
   }, [listboxInstance]);
 
   return (
-    <>
-      <Box
-        height='100%'
-        border={showBorder ? '1px solid #d9d9d9' : '1px solid transparent'}
-        borderBottom={(showBorder && borderBottom) ? '1px solid #d9d9d9' : 0}
-        borderRadius='4px'
-        overflow='hidden'
-        ref={elRef}
-      />
-    </>
+    <Box
+      height='100%'
+      border={showBorder ? '1px solid #d9d9d9' : '1px solid transparent'}
+      borderBottom={(showBorder && borderBottom) ? '1px solid #d9d9d9' : 0}
+      borderRadius='4px'
+      overflow='hidden'
+      ref={elRef}
+    />
   );
 };
 

--- a/packages/sn-filter-pane/src/components/ListboxContainer.tsx
+++ b/packages/sn-filter-pane/src/components/ListboxContainer.tsx
@@ -10,6 +10,7 @@ import useDirectQuery from '../hooks/direct-query/use-direct-query';
 
 interface ListboxContainerProps {
   layout: IListLayout;
+  model: EngineAPI.IGenericObject;
   borderBottom?: boolean;
   disableSearch?: boolean;
   handleActive?: (id: string, active: boolean) => void;
@@ -19,7 +20,7 @@ interface ListboxContainerProps {
 }
 
 const ListboxContainer = ({
-  layout, borderBottom, disableSearch = false, handleActive, stores, closePopover, isPopover,
+  layout, model, borderBottom, disableSearch = false, handleActive, stores, closePopover, isPopover,
 }: ListboxContainerProps) => {
   const [listboxInstance, setListboxInstance] = useState<stardust.FieldInstance>();
   const elRef = useRef<HTMLElement>();
@@ -27,7 +28,6 @@ const ListboxContainer = ({
 
   const {
     embed,
-    model,
     constraints,
     options,
     renderTracker,
@@ -39,7 +39,7 @@ const ListboxContainer = ({
   const { sense } = env as IEnv;
 
   const dqOptionsOverrides = useDirectQuery({
-    directQueryEnabled, layout, sessionModel: model, constraints,
+    directQueryEnabled, layout, listBoxModel: model, constraints,
   });
 
   const showBorder = !sense || inSelection || stardustTheme?.getStyle('', '', '_cards');

--- a/packages/sn-filter-pane/src/components/ListboxGrid/ListboxGrid.tsx
+++ b/packages/sn-filter-pane/src/components/ListboxGrid/ListboxGrid.tsx
@@ -166,6 +166,7 @@ function ListboxGrid({ stores }: { stores: IStores }) {
                       {item.expand
                         ? <ListboxContainer
                               layout={item.layout}
+                              model={item.model}
                           borderBottom={(column.items?.length === j + 1) || !item.fullyExpanded}
                               disableSearch={item.cardinal <= 3}
                               handleActive={handleActive}

--- a/packages/sn-filter-pane/src/components/ListboxGrid/ListboxGrid.tsx
+++ b/packages/sn-filter-pane/src/components/ListboxGrid/ListboxGrid.tsx
@@ -27,6 +27,7 @@ import KEYS from '../keys';
 import { RenderTrackerService } from '../../services/render-tracker';
 import useFocusListener from '../../hooks/use-focus-listener';
 import findNextIndex from './find-next-index';
+import { IEnv } from '../../types/types';
 
 // TODO: Remove
 const Resizable = styled(ResizableBox)(() => ({
@@ -43,8 +44,10 @@ const prepareRenderTracker = (listboxCount: number, renderTracker?: RenderTracke
 function ListboxGrid({ stores }: { stores: IStores }) {
   const { store, resourceStore } = stores;
   const {
-    sense, selections, keyboard, renderTracker,
+    env = {}, selections, keyboard, renderTracker,
   } = store.getState();
+
+  const { sense } = env as IEnv;
 
   // Subscribe to the resourceStore outside of react and re-render on store change.
   const { resources } = useSyncExternalStore(resourceStore.subscribe, resourceStore.getState);

--- a/packages/sn-filter-pane/src/components/ListboxPopoverContainer.tsx
+++ b/packages/sn-filter-pane/src/components/ListboxPopoverContainer.tsx
@@ -11,6 +11,7 @@ import { FoldedListbox } from './FoldedListbox';
 import { FoldedListboxClickEvent } from './FoldedListbox/FoldedListbox';
 import ListboxContainer from './ListboxContainer';
 import KEYS from './keys';
+import { IEnv } from '../types/types';
 
 export interface FoldedPopoverProps {
   resources: IListboxResource[];
@@ -53,7 +54,8 @@ const StyledDiv = styled('div')(() => ({
  * FoldedLisbox:es are rendered which in themselves are clickable.
  */
 export const ListboxPopoverContainer = ({ resources, stores }: FoldedPopoverProps) => {
-  const { constraints, stardustTheme, sense } = stores.store.getState();
+  const { constraints, stardustTheme, env = {} } = stores.store.getState();
+  const { sense } = env as IEnv;
   const [popoverOpen, setPopoverOpen] = useState(false);
   const containerRef = useRef(null);
   const [selectedResource, setSelectedResource] = useState<IListboxResource | undefined>();

--- a/packages/sn-filter-pane/src/components/ListboxPopoverContainer.tsx
+++ b/packages/sn-filter-pane/src/components/ListboxPopoverContainer.tsx
@@ -222,7 +222,7 @@ export const ListboxPopoverContainer = ({ resources, stores }: FoldedPopoverProp
         className='listbox-popover'
       >
         {(selectedResource || isSingle)
-          ? <ListboxContainer layout={selectedResource?.layout ?? resources[0].layout} stores={stores} closePopover={closePopover} isPopover={true} />
+          ? <ListboxContainer model={selectedResource?.model} layout={selectedResource?.layout ?? resources[0].layout} stores={stores} closePopover={closePopover} isPopover={true} />
           : <Grid container direction='column' spacing={1} padding='8px' className='folded-listbox-dropdown' onKeyDown={onFoldedListboxDropdownKeyDown}>
             {!!resources?.length && resources?.map((resource) => (
               <Grid item key={resource.id}>

--- a/packages/sn-filter-pane/src/ext/property-panel/data/data-panel/presentation/index.ts
+++ b/packages/sn-filter-pane/src/ext/property-panel/data/data-panel/presentation/index.ts
@@ -4,10 +4,14 @@ import textAlignItems from '../../text-align-items';
 import { IEnv } from '../../../../../types/types';
 import frequencies from '../../../constants';
 import updateForFrequencyMax from '../update-frequency-max';
+import { INxAppLayout } from '../../../../../hooks/types/index.d';
+import isDirectQueryEnabled from '../../../../../hooks/direct-query/is-direct-query-enabled';
 
 const DEFAULT_LAYOUT_ORDER = 'column';
 
 const change = updateForFrequencyMax;
+
+const readOnly = (_properties: unknown, _handler: unknown, args: { app: { layout: INxAppLayout } }) => isDirectQueryEnabled({ env, appLayout: args?.app?.layout }), ;
 
 export default function getPresentation(env: IEnv) {
   const { translator } = env;
@@ -28,6 +32,7 @@ export default function getPresentation(env: IEnv) {
         translation: 'properties.filterpane.showCheckboxes',
         component: 'checkbox',
         defaultValue: false,
+        readOnly,
       },
       histogram: {
         ref: 'histogram',
@@ -36,6 +41,7 @@ export default function getPresentation(env: IEnv) {
         translation: 'properties.filterpane.showHistogram',
         defaultValue: false,
         change,
+        readOnly,
       },
       frequencyCountModeGroup: {
         translation: 'properties.frequencyCountMode',
@@ -47,8 +53,9 @@ export default function getPresentation(env: IEnv) {
             type: 'string',
             component: 'dropdown',
             defaultValue: frequencies.FREQUENCY_NONE,
-            show() {
-              return isEnabled('LIST_BOX_FREQUENCY_COUNT');
+            show(_properties: unknown, _handler: unknown, args: { app: { layout: INxAppLayout } }) {
+              const isDQ = isDirectQueryEnabled({ env, appLayout: args?.app?.layout });
+              return !isDQ && isEnabled('LIST_BOX_FREQUENCY_COUNT');
             },
             translation: 'properties.frequencyCountMode',
             options: [

--- a/packages/sn-filter-pane/src/ext/property-panel/data/data-panel/presentation/index.ts
+++ b/packages/sn-filter-pane/src/ext/property-panel/data/data-panel/presentation/index.ts
@@ -11,7 +11,7 @@ const DEFAULT_LAYOUT_ORDER = 'column';
 
 const change = updateForFrequencyMax;
 
-const readOnly = (_properties: unknown, _handler: unknown, args: { app: { layout: INxAppLayout } }) => isDirectQueryEnabled({ env, appLayout: args?.app?.layout }), ;
+const readOnly = (_properties: unknown, _handler: unknown, args: { app: { layout: INxAppLayout } }) => isDirectQueryEnabled({ env, appLayout: args?.app?.layout });
 
 export default function getPresentation(env: IEnv) {
   const { translator } = env;

--- a/packages/sn-filter-pane/src/ext/property-panel/data/data-panel/presentation/index.ts
+++ b/packages/sn-filter-pane/src/ext/property-panel/data/data-panel/presentation/index.ts
@@ -11,11 +11,10 @@ const DEFAULT_LAYOUT_ORDER = 'column';
 
 const change = updateForFrequencyMax;
 
-const readOnly = (_properties: unknown, _handler: unknown, args: { app: { layout: INxAppLayout } }) => isDirectQueryEnabled({ env, appLayout: args?.app?.layout });
-
 export default function getPresentation(env: IEnv) {
   const { translator } = env;
   const { isEnabled } = env?.flags || {};
+  const readOnly = (_properties: unknown, _handler: unknown, args: { app: { layout: INxAppLayout } }) => isDirectQueryEnabled({ env, appLayout: args?.app?.layout });
   return {
     type: 'items',
     translation: 'properties.presentation',

--- a/packages/sn-filter-pane/src/hooks/direct-query/dq-properties-utils.ts
+++ b/packages/sn-filter-pane/src/hooks/direct-query/dq-properties-utils.ts
@@ -1,0 +1,41 @@
+import { IListLayout, IPage } from '../types';
+
+export function canSetProperties(layout: IListLayout) {
+  const yesICan = !!(
+    layout
+    && !layout.qHasSoftPatches
+    && !layout.qExtendsId
+    && (layout.qMeta?.privileges || []).indexOf('update') > -1
+  );
+  return yesICan;
+}
+
+/**
+ * Set qHeight of each page corresponding to the number of items of that page,
+ * since this is not done correctly in the backend in DQ mode (to be fixed in Engine).
+ *
+ */
+function postProcessPages(pages: IPage[]) {
+  const newPages = pages.map((page: IPage) => {
+    const qArea = {
+      ...page.qArea,
+      qHeight: page.qMatrix.length,
+    };
+    return {
+      ...page,
+      qArea,
+    };
+  });
+  return newPages;
+}
+
+export function getDirectQueryOptions() {
+  return {
+    __DO_NOT_USE__: {
+      focusSearch: true,
+      showGray: false,
+      postProcessPages,
+      calculatePagesHeight: true,
+    },
+  };
+}

--- a/packages/sn-filter-pane/src/hooks/direct-query/is-direct-query-enabled.ts
+++ b/packages/sn-filter-pane/src/hooks/direct-query/is-direct-query-enabled.ts
@@ -1,0 +1,12 @@
+import { IEnv } from '../../types/types';
+import { INxAppLayout } from '../types';
+
+interface IIsDirectQueryEnabled {
+  env: IEnv;
+  appLayout: INxAppLayout;
+}
+
+export default function isDirectQueryEnabled({ env, appLayout }: IIsDirectQueryEnabled) {
+  const { isEnabled = () => false } = env?.flags || {};
+  return !!(appLayout?.qIsDirectQueryMode && (isEnabled('CLIENT_DIRECT_QUERY_EAP') || isEnabled('CLIENT_DIRECT_QUERY_GA')));
+}

--- a/packages/sn-filter-pane/src/hooks/direct-query/json-patch.js
+++ b/packages/sn-filter-pane/src/hooks/direct-query/json-patch.js
@@ -1,0 +1,284 @@
+import extend from 'extend';
+
+const { isArray } = Array;
+
+const isObject = (v) => !!v && typeof v === 'object' && !isArray(v);
+
+const isUndef = (v) => typeof v === 'undefined';
+
+const isFunction = (v) => typeof v === 'function';
+
+const clone = (obj) => extend(true, {}, obj);
+
+/**
+ * An additional type checker used to determine if the property is of internal
+ * use or not a type that can be translated into JSON (like functions).
+ *
+ * @private
+ * @param {Object} obj The object which has the property to check
+ * @param {String} The property name to check
+ * @returns {Boolean} Whether the property is deemed special or not
+ */
+function isSpecialProperty(obj, key) {
+  return isFunction(obj[key]) || key.substring(0, 2) === '$$' || key.substring(0, 1) === '_';
+}
+
+/**
+ * Finds the parent object from a JSON-Pointer ("/foo/bar/baz" = "bar" is "baz" parent),
+ * also creates the object structure needed.
+ *
+ * @private
+ * @param {Object} data The root object to traverse through
+ * @param {String} The JSON-Pointer string to use when traversing
+ * @returns {Object} The parent object
+ */
+function getParent(data, str) {
+  const seperator = '/';
+  const parts = str.substring(1).split(seperator).slice(0, -1);
+  let numPart;
+
+  parts.forEach((part, i) => {
+    if (i === parts.length) {
+      return;
+    }
+    numPart = +part;
+    // eslint-disable-next-line no-nested-ternary, no-param-reassign
+    data[numPart || part] = isUndef(data[numPart || part]) ? (!Number.isNaN(+numPart) ? [] : {}) : data[part];
+    // eslint-disable-next-line no-nested-ternary, no-param-reassign
+    data = data[numPart || part];
+  });
+
+  return data;
+}
+
+/**
+ * Cleans an object of all its properties, unless they're deemed special or
+ * cannot be removed by configuration.
+ *
+ * @private
+ * @param {Object} obj The object to clean
+ */
+function emptyObject(obj) {
+  Object.keys(obj).forEach((key) => {
+    const config = Object.getOwnPropertyDescriptor(obj, key);
+
+    if (config.configurable && !isSpecialProperty(obj, key)) {
+      delete obj[key];
+    }
+  });
+}
+
+/**
+ * Compare an object with another, could be object, array, number, string, bool.
+ *
+ * @param {Object} a The first object to compare
+ * @param {Object} b The second object to compare
+ * @returns {Boolean} Whether the objects are identical
+ */
+function objectsAreIdentical(a, b) {
+  if (isObject(a) && isObject(b)) {
+    if (Object.keys(a).length !== Object.keys(b).length) {
+      return false;
+    }
+    const someAreNotSame = Object.keys(a).some((key) => !objectsAreIdentical(a[key], b[key]));
+    return !someAreNotSame;
+  }
+  if (isArray(a) && isArray(b)) {
+    if (a.length !== b.length) {
+      return false;
+    }
+    const someAreNotSame = a.some((key) => !objectsAreIdentical(a[key], b[key]));
+    return !someAreNotSame;
+  }
+  return a === b;
+}
+
+/**
+ * Generates patches by comparing two arrays.
+ *
+ * @private
+ * @param {Array} oldA The old (original) array, which will be patched
+ * @param {Array} newA The new array, which will be used to compare against
+ * @returns {Array} An array of patches (if any)
+ */
+function patchArray(original, newA, basePath) {
+  let patches = [];
+  const oldA = original.slice();
+  let i;
+  let l;
+  let tmpIdx = -1;
+
+  function findIndex(a, id, idx) {
+    if (a[idx] && isUndef(a[idx].qInfo)) {
+      return null;
+    }
+    if (a[idx] && a[idx].qInfo.qId === id) {
+      // shortcut if identical
+      return idx;
+    }
+    for (let i = 0, l = a.length; i < l; i++) {
+      if (a[i] && a[i].qInfo.qId === id) {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+  if (objectsAreIdentical(newA, oldA)) {
+    // array is unchanged
+    return patches;
+  }
+
+  if (newA[0] === null || (!isUndef(newA[0]) && isUndef(newA[0].qInfo))) {
+    // we cannot create patches without unique identifiers, replace array...
+    patches.push({
+      op: 'replace',
+      path: basePath,
+      value: newA,
+    });
+    return patches;
+  }
+
+  for (i = oldA.length - 1; i >= 0; --i) {
+    tmpIdx = findIndex(newA, oldA[i] && oldA[i].qInfo && oldA[i].qInfo.qId, i);
+    if (tmpIdx === -1) {
+      patches.push({
+        op: 'remove',
+        path: `${basePath}/${i}`,
+      });
+      oldA.splice(i, 1);
+    } else {
+      // eslint-disable-next-line no-use-before-define
+      patches = patches.concat(generateJsonPatch(oldA[i], newA[tmpIdx], `${basePath}/${i}`));
+    }
+  }
+
+  for (i = 0, l = newA.length; i < l; ++i) {
+    tmpIdx = findIndex(oldA, newA[i] && newA[i].qInfo && newA[i].qInfo.qId);
+    if (tmpIdx === -1) {
+      patches.push({
+        op: 'add',
+        path: `${basePath}/${i}`,
+        value: newA[i],
+      });
+      oldA.splice(i, 0, newA[i]);
+    } else if (tmpIdx !== i) {
+      patches.push({
+        op: 'move',
+        path: `${basePath}/${i}`,
+        from: `${basePath}/${tmpIdx}`,
+      });
+      oldA.splice(i, 0, oldA.splice(tmpIdx, 1)[0]);
+    }
+  }
+  return patches;
+}
+
+/**
+ * Generate an array of JSON-Patch:es following the JSON-Patch Specification Draft.
+ *
+ * See [specification draft](http://tools.ietf.org/html/draft-ietf-appsawg-json-patch-10)
+ *
+ * Does NOT currently generate patches for arrays (will replace them)
+ *
+ * @param {Object} original The object to patch to
+ * @param {Object} newData The object to patch from
+ * @param {String} [basePath] The base path to use when generating the paths for the patches (normally not used)
+ * @returns {Array} An array of patches
+ */
+export function generateJsonPatch(original = {}, newData = {}, basePath = '') {
+  let patches = [];
+
+  Object.keys(newData).forEach((key) => {
+    const val = clone(newData[key]);
+    const oldVal = original[key];
+    const tmpPath = `${basePath}/${key}`;
+
+    if (objectsAreIdentical(val, oldVal) || isSpecialProperty(newData, key)) {
+      return;
+    }
+    if (isUndef(oldVal)) {
+      // property does not previously exist
+      patches.push({
+        op: 'add',
+        path: tmpPath,
+        value: val,
+      });
+    } else if (isObject(val) && isObject(oldVal)) {
+      // we need to generate sub-patches for this, since it already exist
+      patches = patches.concat(generateJsonPatch(oldVal, val, tmpPath));
+    } else if (isArray(val) && isArray(oldVal)) {
+      patches = patches.concat(patchArray(oldVal, val, tmpPath));
+    } else {
+      // it's a simple property (bool, string, number)
+      patches.push({
+        op: 'replace',
+        path: `${basePath}/${key}`,
+        value: val,
+      });
+    }
+  });
+
+  Object.keys(original).forEach((key) => {
+    if (isUndef(newData[key]) && !isSpecialProperty(original, key)) {
+      // this property does not exist anymore
+      patches.push({
+        op: 'remove',
+        path: `${basePath}/${key}`,
+      });
+    }
+  });
+
+  return patches;
+}
+
+/**
+ * Apply a list of patches to an object.
+ *
+ * @param {Object} original The object to patch
+ * @param {Array} patches The list of patches to apply
+ */
+export function applyJsonPatch(original, patches) {
+  patches.forEach((patch) => {
+    const parent = getParent(original, patch.path);
+    let key = patch.path.split('/').splice(-1)[0];
+    const target = key && Number.isNaN(+key) ? parent[key] : parent[+key] || parent;
+    const from = patch.from ? patch.from.split('/').splice(-1)[0] : null;
+
+    if (patch.op === 'add' || patch.op === 'replace') {
+      if (isArray(parent)) {
+        // trust indexes from patches, so don't replace the index if it's an add
+        if (key === '-') {
+          key = parent.length;
+        }
+        parent.splice(+key, patch.op === 'add' ? 0 : 1, patch.value);
+      } else if (isArray(target) && isArray(patch.value)) {
+        const newValues = patch.value.slice();
+        // keep array reference if possible...
+        target.length = 0;
+        target.push(target, ...newValues);
+      } else if (isObject(target) && isObject(patch.value)) {
+        // keep object reference if possible...
+        emptyObject(target);
+        extend(true, target, patch.value);
+      } else {
+        // simple value
+        parent[key] = patch.value;
+      }
+    } else if (patch.op === 'move') {
+      const oldParent = getParent(original, patch.from);
+      if (isArray(parent)) {
+        parent.splice(+key, 0, oldParent.splice(+from, 1)[0]);
+      } else {
+        parent[key] = oldParent[from];
+        delete oldParent[from];
+      }
+    } else if (patch.op === 'remove') {
+      if (isArray(parent)) {
+        parent.splice(+key, 1);
+      } else {
+        delete parent[key];
+      }
+    }
+  });
+}

--- a/packages/sn-filter-pane/src/hooks/direct-query/soft-property-handler.js
+++ b/packages/sn-filter-pane/src/hooks/direct-query/soft-property-handler.js
@@ -1,0 +1,48 @@
+import extend from 'extend';
+import { applyJsonPatch, generateJsonPatch } from './json-patch';
+
+export default class SoftPropertyHandler {
+  constructor(model) {
+    this.model = model;
+  }
+
+  async saveSoftProperties(prevEffectiveProperties, effectiveProperties) {
+    if (!this.model) {
+      return false;
+    }
+
+    const patches = generateJsonPatch(prevEffectiveProperties, effectiveProperties);
+    const mergedProperties = extend(true, {}, prevEffectiveProperties, effectiveProperties);
+
+    if (!patches?.length) {
+      return false;
+    }
+    const bakedPatches = patches.map((p) => ({
+      qOp: p.op,
+      qValue: JSON.stringify(p.value),
+      qPath: p.path,
+    }));
+
+    try {
+      await this.model.applyPatches(bakedPatches, true);
+    } catch (_err) {
+      return false;
+    }
+    return mergedProperties;
+  }
+
+  async mergeSoftPatches() {
+    if (!this.model) {
+      return;
+    }
+
+    const [properties, effective] = await Promise.all([this.model.getProperties(), this.model.getEffectiveProperties()]);
+    if (properties.qExtendsId) {
+      return;
+    }
+    const patches = generateJsonPatch(properties, effective);
+    applyJsonPatch(properties, patches);
+    await this.model.setProperties(properties);
+    await this.model.clearSoftPatches();
+  }
+}

--- a/packages/sn-filter-pane/src/hooks/direct-query/use-direct-query.js
+++ b/packages/sn-filter-pane/src/hooks/direct-query/use-direct-query.js
@@ -1,0 +1,29 @@
+import { useEffect } from 'react';
+import SoftPropertyHandler from './soft-property-handler';
+import { canSetProperties, getDirectQueryOptions } from './dq-properties-utils';
+
+export default function useDirectQuery({
+  directQueryEnabled, layout, listBoxModel, constraints,
+}) {
+  // Detect e.g. analysis/edit mode switch.
+  const constraintsAsString = Object.entries(constraints || {}).join(',');
+
+  useEffect(() => {
+    if (!directQueryEnabled || !layout || !listBoxModel) {
+      return;
+    }
+    // When using an existing model, we need to send checkboxes through properties and not options.
+    const softPropertyHandler = new SoftPropertyHandler(listBoxModel);
+    listBoxModel.getProperties().then(async (oldProps = {}) => {
+      const newProperties = { ...oldProps, checkboxes: true };
+      if (canSetProperties(layout)) {
+        await listBoxModel.setProperties(newProperties);
+      } else {
+        await softPropertyHandler.saveSoftProperties(oldProps, newProperties);
+      }
+    });
+  }, [layout, directQueryEnabled, listBoxModel, constraintsAsString]);
+
+  const options = directQueryEnabled ? getDirectQueryOptions() : undefined;
+  return options;
+}

--- a/packages/sn-filter-pane/src/hooks/types/index.d.ts
+++ b/packages/sn-filter-pane/src/hooks/types/index.d.ts
@@ -1,7 +1,13 @@
-import { IListLayout as GlobalIListLayout, IGenericListPropertiesMissing as IGenericListPropertiesMissingGlobal } from '../../../../../types/global';
+import { IListLayout as GlobalIListLayout, IGenericListPropertiesMissing as IGenericListPropertiesMissingGlobal, INxAppLayoutGlobal } from '../../../../../types/global';
 
 export type IListLayout = GlobalIListLayout;
 export type IGenericListPropertiesMissing = IGenericListPropertiesMissingGlobal;
+export type INxAppLayout = INxAppLayoutGlobal;
+
+export type IPage = {
+  qArea: object;
+  qMatrix: object[];
+};
 
 export interface IContainerElement extends HTMLDivElement {
   current: HTMLElement

--- a/packages/sn-filter-pane/src/hooks/use-setup.ts
+++ b/packages/sn-filter-pane/src/hooks/use-setup.ts
@@ -1,16 +1,19 @@
 import {
-  useEmbed, useApp, useLayout, useModel, useOptions, useConstraints, useState, useTranslator, useTheme, useSelections, useKeyboard,
+  useEmbed, useApp, useLayout, useModel, useOptions, useConstraints, useState, useTranslator, useTheme, useSelections, useKeyboard, useAppLayout,
 } from '@nebula.js/stardust';
 import { create } from '../store';
 import { IEnv } from '../types/types';
-import { IFilterPaneLayout, IListBoxOptions } from './types';
+import { IFilterPaneLayout, IListBoxOptions, INxAppLayout } from './types';
 import useRenderTrackerService from '../services/render-tracker';
 
-export default function useSetup({ sense }: IEnv) {
+export default function useSetup(env: IEnv) {
   const [stores] = useState(() => create());
+
+  const { flags } = env;
   const { store } = stores;
   const options = useOptions() as IListBoxOptions;
   const fpLayout = useLayout() as IFilterPaneLayout;
+  const appLayout = useAppLayout() as INxAppLayout;
   const constraints = useConstraints();
   const translator = useTranslator();
   const app = useApp() as EngineAPI.IApp;
@@ -21,11 +24,15 @@ export default function useSetup({ sense }: IEnv) {
   const keyboard = useKeyboard();
   const renderTracker = useRenderTrackerService();
 
+  const { isEnabled = () => false } = flags || {};
+  const directQueryEnabled = !!(appLayout?.qIsDirectQueryMode && (isEnabled('CLIENT_DIRECT_QUERY_EAP') || isEnabled('CLIENT_DIRECT_QUERY_GA')));
+
   store.setState({
     app,
     model,
     fpLayout,
-    sense,
+    env,
+    directQueryEnabled,
     options,
     constraints,
     translator,

--- a/packages/sn-filter-pane/src/hooks/use-setup.ts
+++ b/packages/sn-filter-pane/src/hooks/use-setup.ts
@@ -5,11 +5,11 @@ import { create } from '../store';
 import { IEnv } from '../types/types';
 import { IFilterPaneLayout, IListBoxOptions, INxAppLayout } from './types';
 import useRenderTrackerService from '../services/render-tracker';
+import isDirectQueryEnabled from './direct-query/is-direct-query-enabled';
 
 export default function useSetup(env: IEnv) {
   const [stores] = useState(() => create());
 
-  const { flags } = env;
   const { store } = stores;
   const options = useOptions() as IListBoxOptions;
   const fpLayout = useLayout() as IFilterPaneLayout;
@@ -24,8 +24,7 @@ export default function useSetup(env: IEnv) {
   const keyboard = useKeyboard();
   const renderTracker = useRenderTrackerService();
 
-  const { isEnabled = () => false } = flags || {};
-  const directQueryEnabled = !!(appLayout?.qIsDirectQueryMode && (isEnabled('CLIENT_DIRECT_QUERY_EAP') || isEnabled('CLIENT_DIRECT_QUERY_GA')));
+  const directQueryEnabled: boolean = isDirectQueryEnabled({ env, appLayout });
 
   store.setState({
     app,

--- a/packages/sn-filter-pane/src/index.ts
+++ b/packages/sn-filter-pane/src/index.ts
@@ -16,7 +16,7 @@ export default function supernova(env: IEnv) {
       data: getData(env),
     },
     component() {
-      const stores = useSetup({ ...env });
+      const stores = useSetup(env);
       useContextMenu();
       useRender(stores);
     },

--- a/packages/sn-filter-pane/src/store/index.ts
+++ b/packages/sn-filter-pane/src/store/index.ts
@@ -16,7 +16,7 @@ export interface IStore {
   constraints?: stardust.Constraints;
   translator?: stardust.Translator;
   env?: IEnv;
-  directQueryEnabled: boolean;
+  directQueryEnabled?: boolean;
   embed?: stardust.Embed;
   stardustTheme?: stardust.Theme;
   selections?: stardust.ObjectSelections;

--- a/packages/sn-filter-pane/src/store/index.ts
+++ b/packages/sn-filter-pane/src/store/index.ts
@@ -4,7 +4,7 @@ import {
   IListBoxOptions,
   IListboxResource,
 } from '../hooks/types';
-import { ISense } from '../types/types';
+import { IEnv } from '../types/types';
 import { RenderTrackerService } from '../services/render-tracker';
 import createStore from './state-store';
 
@@ -15,7 +15,8 @@ export interface IStore {
   options: IListBoxOptions;
   constraints?: stardust.Constraints;
   translator?: stardust.Translator;
-  sense?: ISense;
+  env?: IEnv;
+  directQueryEnabled: boolean;
   embed?: stardust.Embed;
   stardustTheme?: stardust.Theme;
   selections?: stardust.ObjectSelections;

--- a/packages/sn-filter-pane/tsconfig.json
+++ b/packages/sn-filter-pane/tsconfig.json
@@ -11,7 +11,8 @@
     "esModuleInterop": true,
     "module": "ESNext",
     "noImplicitReturns": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "./dist"
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules"]

--- a/packages/sn-listbox/tsconfig.json
+++ b/packages/sn-listbox/tsconfig.json
@@ -47,7 +47,7 @@
     // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
     // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If `declaration` is true, also designates a file that bundles all .d.ts output. */
-    "outDir": "./dist",                                   /* Specify an output folder for all emitted files. */
+    // "outDir": "./dist",                                   /* Specify an output folder for all emitted files. */
     // "removeComments": true,                           /* Disable emitting comments. */
     // "noEmit": true,                                   /* Disable emitting files from a compilation. */
     // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */

--- a/packages/sn-listbox/tsconfig.json
+++ b/packages/sn-listbox/tsconfig.json
@@ -47,7 +47,7 @@
     // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
     // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If `declaration` is true, also designates a file that bundles all .d.ts output. */
-    "outDir": "./dist"                                   /* Specify an output folder for all emitted files. */
+    "outDir": "./dist",                                   /* Specify an output folder for all emitted files. */
     // "removeComments": true,                           /* Disable emitting comments. */
     // "noEmit": true,                                   /* Disable emitting files from a compilation. */
     // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */

--- a/packages/sn-listbox/tsconfig.json
+++ b/packages/sn-listbox/tsconfig.json
@@ -47,7 +47,7 @@
     // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
     // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If `declaration` is true, also designates a file that bundles all .d.ts output. */
-    // "outDir": "./",                                   /* Specify an output folder for all emitted files. */
+    "outDir": "./dist"                                   /* Specify an output folder for all emitted files. */
     // "removeComments": true,                           /* Disable emitting comments. */
     // "noEmit": true,                                   /* Disable emitting files from a compilation. */
     // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -9,6 +9,11 @@ export interface IListLayout extends EngineAPI.IGenericListLayout {
     dataLayout?: 'grid' | 'singleColumn',
   },
   showTitle?: boolean,
+  qHasSoftPatches?: boolean;
+  qExtendsId?: string;
+  qMeta?: {
+    privileges?: string[];
+  }
 }
 
 // Missing properties in EngineAPI.IGenericListProperties are added in this interface until
@@ -35,4 +40,8 @@ export interface IGenericListPropertiesMissing {
       }
     }
   }
+}
+
+export interface INxAppLayoutGlobal extends EngineAPI.INxAppLayout {
+  qIsDirectQueryMode: boolean;
 }


### PR DESCRIPTION
Move the logic previously residing in sense-client, into Filter pane so that we can [soon] completely replace the Angular Filter pane there.

To be added (probably in another PR): Unit tests.