### PR TITLE
fix: flickering border

### DIFF
--- a/packages/sn-filter-pane/src/components/FoldedListbox/FoldedListbox.tsx
+++ b/packages/sn-filter-pane/src/components/FoldedListbox/FoldedListbox.tsx
@@ -63,18 +63,14 @@ const StyledGrid = styled(Grid, { shouldForwardProp: (p) => !['constraints', 'st
       height: COLLAPSED_HEIGHT,
       overflow: 'hidden',
       cursor: constraints?.active ? 'default' : 'pointer',
+      transition: 'border .2s ease-out',
       ':hover': !constraints?.active && {
         border: '1px solid #595959',
+        transition: 'border 0s',
       },
       backgroundColor: stardustTheme?.getStyle('object', '', 'listBox.backgroundColor') ?? '#FFFFFF',
       color: stardustTheme?.getStyle('object', '', 'listBox.title.main.color') ?? '#404040',
       width: containerWidth - popoverPadding,
-      '&:focus:not(:hover)': {
-        boxShadow: 'inset 0 0 0 2px #3F8AB3 !important',
-      },
-      '&:focus-visible': {
-        outline: 'none',
-      },
     };
   },
 );

--- a/packages/sn-filter-pane/src/components/ListboxPopoverContainer.tsx
+++ b/packages/sn-filter-pane/src/components/ListboxPopoverContainer.tsx
@@ -37,14 +37,10 @@ const popoverPaperProps = (selectedResource: boolean, isSmallDevice:boolean, sta
 };
 
 const StyledDiv = styled('div')(() => ({
-  '&:focus:not(:hover)': {
+  '&:focus-visible': {
     outline: '2px solid #3F8AB3',
     outlineOffset: '-2px',
     borderRadius: '4px',
-
-  },
-  '&:focus-visible': {
-    outline: 'none',
   },
   padding: '2px',
   paddingBottom: '0px',
@@ -214,7 +210,7 @@ export const ListboxPopoverContainer = ({ resources, stores }: FoldedPopoverProp
         open={popoverOpen}
         onClose={handleClose}
         anchorEl={containerRef.current}
-        transitionDuration={transitionDuration}
+        transitionDuration={{ enter: transitionDuration, exit: 0 }}
         anchorOrigin={{
           vertical: 'bottom',
           horizontal: 'left',


### PR DESCRIPTION
fixes #282 

When closing a listbox popover, the filterpane rerenders and sense-client applies a blocking layer that causes the hovering border to disappear until the render is finished.
With this fix, the border is delayed when removed and thus suppresses the flickering a bit.

I'm not sure about the look of the delay during normal hovering though...


Before:
![Kapture 2023-04-24 at 15 39 01](https://user-images.githubusercontent.com/99665802/234013969-99f63080-e376-416c-a274-a50e8112388f.gif)

After:
![Kapture 2023-04-24 at 15 22 56](https://user-images.githubusercontent.com/99665802/234011337-3cf5427c-bd2b-4abd-baf9-e34515083bb1.gif)
