### PR TITLE
refactor: disable qlik sense navmenu by default

### DIFF
--- a/packages/sn-filter-pane/src/qae/listbox-properties.ts
+++ b/packages/sn-filter-pane/src/qae/listbox-properties.ts
@@ -45,7 +45,7 @@ const defaultListboxProps = {
   showTitles: false,
   subtitle: '',
   footnote: '',
-  disableNavMenu: false,
+  disableNavMenu: true,
   showDetails: false,
   showDetailsExpression: false,
   qStateName: '',

--- a/packages/sn-listbox/src/object-properties.ts
+++ b/packages/sn-listbox/src/object-properties.ts
@@ -46,7 +46,7 @@ const properties = {
   showTitles: false,
   subtitle: '',
   footnote: '',
-  disableNavMenu: false,
+  disableNavMenu: true,
   showDetails: false,
   showDetailsExpression: false,
   qStateName: '',


### PR DESCRIPTION
Changes default setting of `disableNavMenu` which is the "hover menu" within Qlik Sense. This decision was taken after discussions with UX to mitigate problems with hover menu overlapping important things in the UI.