### PR TITLE
fix: adapt expand button to narrow container

### DIFF
--- a/packages/sn-filter-pane/src/components/ExpandButton.tsx
+++ b/packages/sn-filter-pane/src/components/ExpandButton.tsx
@@ -1,8 +1,9 @@
-import { Button, styled } from '@mui/material';
+import { Button, Grid, styled } from '@mui/material';
 import React from 'react';
 import ExpandMore from '@mui/icons-material/ExpandMore';
 import { BUTTON_HEIGHT } from './ListboxGrid/distribute-resources';
 import type { IStores } from '../store';
+import POPOVER_CONTAINER_PADDING from './FoldedListbox/constants';
 
 export interface FoldedListboxProps {
   onClick?: (event: { event: React.MouseEvent<HTMLButtonElement> }) => void;
@@ -17,7 +18,7 @@ export interface IconProps {
 export const ExpandButton = ({
   onClick, opened, stores,
 }: FoldedListboxProps) => {
-  const { constraints, stardustTheme } = stores.store.getState();
+  const { constraints, stardustTheme, containerSize } = stores.store.getState();
 
   const ExpandIcon = styled(ExpandMore)<IconProps>(({ open }) => ({
     color: '#555555',
@@ -25,17 +26,27 @@ export const ExpandButton = ({
     transform: open ? 'rotate(180deg)' : 'rotate(0deg)',
   }));
 
-  const StyledButton = styled(Button)(() => ({
-    backgroundColor: stardustTheme?.getStyle('object', '', 'listBox.backgroundColor') ?? '#FFFFFF',
-    width: '100%',
-    height: BUTTON_HEIGHT,
-    border: '1px solid #B3B3B3',
-    borderRadius: '3px',
-    justifyContent: 'end',
+  const StyledButton = styled(Button)(() => {
+    let height = BUTTON_HEIGHT;
+    if (containerSize?.height && containerSize?.height < BUTTON_HEIGHT + POPOVER_CONTAINER_PADDING) {
+      height = containerSize.height - POPOVER_CONTAINER_PADDING - 1;
+    }
+    return {
+      backgroundColor: stardustTheme?.getStyle('object', '', 'listBox.backgroundColor') ?? '#FFFFFF',
+      width: '100%',
+      height,
+      border: '1px solid #B3B3B3',
+      borderRadius: '3px',
+      justifyContent: 'end',
+    };
+  });
+
+  const StyledDiv = styled('div')(() => ({
+    display: 'flex',
   }));
 
   return (
-    <>
+    <StyledDiv>
       <StyledButton
         onClick={(event) => onClick?.({ event })}
         disableRipple
@@ -44,6 +55,6 @@ export const ExpandButton = ({
       >
         <ExpandIcon open={opened}></ExpandIcon>
       </StyledButton>
-    </>
+    </StyledDiv>
   );
 };

--- a/packages/sn-filter-pane/src/components/FoldedListbox/FoldedListbox.tsx
+++ b/packages/sn-filter-pane/src/components/FoldedListbox/FoldedListbox.tsx
@@ -99,7 +99,7 @@ export const FoldedListbox = ({
   const isDrillDown = resource.layout.qListObject.qDimensionInfo.qGrouping === 'H';
   const {
     gridHeight, narrowSmall, narrowLarge,
-  } = getSizes(containerSize);
+  } = getSizes(containerSize, isInPopover);
 
   const handleKeyDown = (event: React.KeyboardEvent) => {
     const target = event.target as HTMLElement;

--- a/packages/sn-filter-pane/src/components/FoldedListbox/__tests__/get-sizes.spec.ts
+++ b/packages/sn-filter-pane/src/components/FoldedListbox/__tests__/get-sizes.spec.ts
@@ -1,6 +1,7 @@
 import { ISize } from '../../ListboxGrid/interfaces';
 import POPOVER_CONTAINER_PADDING from '../../FoldedListbox/constants';
 import getSizes from '../get-sizes';
+import { COLLAPSED_HEIGHT } from '../../ListboxGrid/distribute-resources';
 
 describe('getSizes', () => {
   it.only('should return correct sizes for narrow-small container', () => {
@@ -8,7 +9,7 @@ describe('getSizes', () => {
       height: 20,
     };
 
-    const sizes = getSizes(containerSize as ISize);
+    const sizes = getSizes(containerSize as ISize, false);
 
     expect(sizes.gridHeight).toBe(containerSize.height - POPOVER_CONTAINER_PADDING - 1);
     expect(sizes.narrowSmall).toBe(true);
@@ -20,7 +21,7 @@ describe('getSizes', () => {
       height: 24,
     };
 
-    const sizes = getSizes(containerSize as ISize);
+    const sizes = getSizes(containerSize as ISize, false);
 
     expect(sizes.gridHeight).toBe(containerSize.height - POPOVER_CONTAINER_PADDING - 1);
     expect(sizes.narrowSmall).toBe(false);
@@ -32,9 +33,19 @@ describe('getSizes', () => {
       height: 25,
     };
 
-    const sizes = getSizes(containerSize as ISize);
+    const sizes = getSizes(containerSize as ISize, false);
 
     expect(sizes.narrowSmall).toBe(false);
     expect(sizes.narrowLarge).toBe(false);
+  });
+
+  it.only('should return collapsed height when isInPopover is true, even in narrow container', () => {
+    const containerSize = {
+      height: 20,
+    };
+
+    const sizes = getSizes(containerSize as ISize, true);
+
+    expect(sizes.gridHeight).toBe(COLLAPSED_HEIGHT);
   });
 });

--- a/packages/sn-filter-pane/src/components/FoldedListbox/get-sizes.ts
+++ b/packages/sn-filter-pane/src/components/FoldedListbox/get-sizes.ts
@@ -2,9 +2,9 @@ import { COLLAPSED_HEIGHT } from '../ListboxGrid/distribute-resources';
 import { ISize } from '../ListboxGrid/interfaces';
 import POPOVER_CONTAINER_PADDING from '../FoldedListbox/constants';
 
-const getSizes = (containerSize?: ISize) => {
+const getSizes = (containerSize?: ISize, isInPopover?: boolean) => {
   const isNarrow = containerSize?.height !== undefined && containerSize?.height < COLLAPSED_HEIGHT + POPOVER_CONTAINER_PADDING;
-  const gridHeight = isNarrow
+  const gridHeight = isNarrow && !isInPopover
     ? containerSize.height - POPOVER_CONTAINER_PADDING - 1
     : COLLAPSED_HEIGHT;
 

--- a/packages/sn-filter-pane/src/components/ListboxPopoverContainer.tsx
+++ b/packages/sn-filter-pane/src/components/ListboxPopoverContainer.tsx
@@ -12,13 +12,12 @@ import { FoldedListboxClickEvent } from './FoldedListbox/FoldedListbox';
 import ListboxContainer from './ListboxContainer';
 import KEYS from './keys';
 import { IEnv } from '../types/types';
+import POPOVER_CONTAINER_PADDING from './FoldedListbox/constants';
 
 export interface FoldedPopoverProps {
   resources: IListboxResource[];
   stores: IStores;
 }
-
-export const POPOVER_CONTAINER_PADDING = 2;
 
 const popoverPaperProps = (selectedResource: boolean, isSmallDevice:boolean, stardustTheme?: stardust.Theme, muiTheme?: Theme): PaperProps => {
   let backgroundColor = stardustTheme?.getStyle('object', '', 'filterpane.backgroundColor');


### PR DESCRIPTION
Calculate narrow height for expand-button.
Don't use narrow height for collapsed Listboxes in popover.
