### PR TITLE
refactor: move handle resize to own hook

### DIFF
--- a/packages/sn-filter-pane/src/components/FoldedListbox/FoldedListbox.tsx
+++ b/packages/sn-filter-pane/src/components/FoldedListbox/FoldedListbox.tsx
@@ -12,7 +12,7 @@ import KEYS from '../keys';
 import getSizes from './get-sizes';
 
 export interface FoldedListboxClickEvent {
-  event: React.MouseEvent<HTMLDivElement>;
+  event: React.MouseEvent<HTMLObjectElement>;
   resource: IListboxResource;
 }
 export interface FoldedListboxProps {

--- a/packages/sn-filter-pane/src/components/ListboxGrid/get-size.ts
+++ b/packages/sn-filter-pane/src/components/ListboxGrid/get-size.ts
@@ -1,4 +1,4 @@
-const getWidthHeight = (ref: React.MutableRefObject<HTMLDivElement | undefined>) => {
+const getWidthHeight = (ref: React.MutableRefObject<HTMLObjectElement | undefined>) => {
   const width = ref?.current?.offsetWidth ?? 0;
   const height = ref?.current?.offsetHeight ?? 0;
   return { width, height };

--- a/packages/sn-filter-pane/src/components/ListboxGrid/use-handle-resize.ts
+++ b/packages/sn-filter-pane/src/components/ListboxGrid/use-handle-resize.ts
@@ -1,0 +1,71 @@
+import {
+  MutableRefObject, useCallback, useState,
+} from 'react';
+import { RenderTrackerService } from '../../services/render-tracker';
+import getWidthHeight from './get-size';
+import {
+  setDefaultValues, balanceColumns, calculateColumns, calculateExpandPriority, mergeColumnsAndResources, hasHeader,
+} from './distribute-resources';
+import { ExpandProps, IColumn, ISize } from './interfaces';
+import { IEnv } from '../../types/types';
+import { IListboxResource } from '../../hooks/types';
+import { IStore } from '../../store';
+
+const prepareRenderTracker = (listboxCount: number, renderTracker?: RenderTrackerService) => {
+  renderTracker?.setNumberOfListboxes(listboxCount);
+  if (listboxCount === 0) {
+    renderTracker?.renderedCallback();
+  }
+};
+
+interface IUseHandleResize {
+  resources: IListboxResource[];
+  gridRef: MutableRefObject<HTMLObjectElement | undefined>;
+  store: IStore;
+  env: IEnv;
+  renderTracker?: RenderTrackerService;
+}
+
+export default function useHandleResize({
+  resources,
+  gridRef,
+  store,
+  env,
+  renderTracker,
+}: IUseHandleResize) {
+  const { sense } = env as IEnv;
+
+  const [overflowingResources, setOverflowingResources] = useState<IListboxResource[]>([]);
+  const [columns, setColumns] = useState<IColumn[]>([]);
+
+  const handleResize = () => {
+    if (!resources?.length) {
+      return;
+    }
+    const { width, height } = getWidthHeight(gridRef);
+    const size: ISize = { width, height, dimensionCount: resources.length };
+    store.setState({ ...store.getState(), containerSize: size });
+    const isSmallDevice = sense?.isSmallDevice?.() ?? false;
+    const isSingleItem = resources.length === 1;
+    const expandProps: ExpandProps = {
+      isSingleGridLayout: isSingleItem && resources[0].layout?.layoutOptions?.dataLayout === 'grid',
+      hasHeader: hasHeader(resources[0]),
+    };
+    const calculatedColumns = calculateColumns(size, [], isSmallDevice, expandProps);
+    const balancedColumns = balanceColumns(size, calculatedColumns, isSmallDevice, expandProps);
+    const resourcesWithDefaultValues = setDefaultValues(resources);
+    const { columns: mergedColumnsAndResources, overflowing } = mergeColumnsAndResources(balancedColumns, resourcesWithDefaultValues);
+    setOverflowingResources(overflowing);
+    const { columns: expandedAndCollapsedColumns, expandedItemsCount } = calculateExpandPriority(mergedColumnsAndResources, size, expandProps);
+    setColumns(expandedAndCollapsedColumns);
+    prepareRenderTracker(expandedItemsCount, renderTracker);
+  };
+
+  const handleResizeMemo = useCallback(() => handleResize(), [resources]);
+
+  return {
+    handleResize: handleResizeMemo,
+    overflowingResources,
+    columns,
+  };
+}

--- a/packages/sn-filter-pane/src/components/ListboxPopoverContainer.tsx
+++ b/packages/sn-filter-pane/src/components/ListboxPopoverContainer.tsx
@@ -221,7 +221,7 @@ export const ListboxPopoverContainer = ({ resources, stores }: FoldedPopoverProp
           vertical: 'bottom',
           horizontal: 'left',
         }}
-        PaperProps={popoverPaperProps(!!selectedResource, isSmallDevice, stardustTheme, muiTheme)}
+        slotProps={{ paper: popoverPaperProps(!!selectedResource, isSmallDevice, stardustTheme, muiTheme) }}
         anchorReference= {isSmallDevice ? 'anchorPosition' : 'anchorEl'}
         anchorPosition= {{ left: 0, top: 0 }}
         marginThreshold={isSmallDevice ? 0 : 16}

--- a/packages/sn-filter-pane/src/hooks/types/index.d.ts
+++ b/packages/sn-filter-pane/src/hooks/types/index.d.ts
@@ -9,7 +9,7 @@ export type IPage = {
   qMatrix: object[];
 };
 
-export interface IContainerElement extends HTMLDivElement {
+export interface IContainerElement extends HTMLObjectElement {
   current: HTMLElement
 }
 

--- a/packages/sn-filter-pane/src/hooks/use-focus-listener.ts
+++ b/packages/sn-filter-pane/src/hooks/use-focus-listener.ts
@@ -26,7 +26,7 @@ const handleFocusoutEvent = (
 };
 
 const useFocusListener = (
-  filterpaneWrapperRef: React.MutableRefObject<HTMLDivElement | undefined>,
+  filterpaneWrapperRef: React.MutableRefObject<HTMLObjectElement | undefined>,
   keyboard: stardust.Keyboard | undefined,
 ) => {
   useEffect(() => {

--- a/packages/sn-filter-pane/src/store/index.ts
+++ b/packages/sn-filter-pane/src/store/index.ts
@@ -9,7 +9,7 @@ import { RenderTrackerService } from '../services/render-tracker';
 import createStore from './state-store';
 import { ISize } from '../components/ListboxGrid/interfaces';
 
-export interface IStore {
+export interface IStoreState {
   app?: EngineAPI.IApp;
   model?: EngineAPI.IGenericObject;
   fpLayout?: IFilterPaneLayout;
@@ -26,11 +26,19 @@ export interface IStore {
   containerSize?: ISize;
 }
 
+export type Listener = () => void;
+
+export interface IStore {
+  getState: () => IStoreState;
+  setState: (obj: IStoreState) => void;
+  subscribe: (listener: Listener) => void;
+}
+
 interface ResourceState {
   resources: IListboxResource[];
 }
 
-const initStoreState: IStore = {
+const initStoreState: IStoreState = {
   options: {},
 };
 

--- a/packages/sn-filter-pane/src/store/state-store.ts
+++ b/packages/sn-filter-pane/src/store/state-store.ts
@@ -1,6 +1,7 @@
+import { Listener } from '.';
+
 const createStore = <T>(createState: () => T) => {
   let state = createState();
-  type Listener = () => void;
   let listeners: Listener[] = [];
 
   const emitChange = () => {

--- a/packages/sn-filter-pane/src/types/types.d.ts
+++ b/packages/sn-filter-pane/src/types/types.d.ts
@@ -3,7 +3,7 @@ interface ISense {
 }
 
 export interface IEnv {
-  flags: {
+  flags?: {
     isEnabled: (flag?: string) => boolean;
   },
   sense?: ISense,


### PR DESCRIPTION
Prepare for adding collapse listbox options by moving out the relevant logic.

Changes:
- Move handle resize to own hook