### PR TITLE
fix: add layout components to listbox resources

### DIFF
--- a/packages/sn-filter-pane/src/hooks/listbox/get-listbox-resources.ts
+++ b/packages/sn-filter-pane/src/hooks/listbox/get-listbox-resources.ts
@@ -1,13 +1,12 @@
 import { IFilterPaneLayout, ListboxResourcesArr } from '../types';
 
-async function getListboxResourcesFromIds(app: EngineAPI.IApp, ids: string[], layout: IFilterPaneLayout): Promise<ListboxResourcesArr> {
+async function getListboxResourcesFromIds(app: EngineAPI.IApp, ids: string[], fpLayout: IFilterPaneLayout): Promise<ListboxResourcesArr> {
   const models = await Promise.all(ids.map((id) => app.getObject(id)));
   const layouts = await Promise.all(models.map((model) => model.getLayout() as unknown as EngineAPI.IGenericListLayout));
-  // add components object for styling
-  console.log('layouts', layouts)
+  // add components array for styling
   if(layouts && layouts.length > 0) {
     layouts.forEach(layoutElem => {
-      layoutElem.components = layout['components'];
+      layoutElem.components = [...fpLayout['components']];
     })
   };
 
@@ -18,7 +17,7 @@ async function getListboxResourcesFromIds(app: EngineAPI.IApp, ids: string[], la
   }));
 }
 
-export default async function getListBoxResources(app: EngineAPI.IApp, layout: IFilterPaneLayout): Promise<ListboxResourcesArr> {
-  const childIds = layout?.qChildList?.qItems.map((item) => item.qInfo.qId) || [];
-  return getListboxResourcesFromIds(app, childIds, layout);
+export default async function getListBoxResources(app: EngineAPI.IApp, fpLayout: IFilterPaneLayout): Promise<ListboxResourcesArr> {
+  const childIds = fpLayout?.qChildList?.qItems.map((item) => item.qInfo.qId) || [];
+  return getListboxResourcesFromIds(app, childIds, fpLayout);
 }

--- a/packages/sn-filter-pane/src/hooks/listbox/get-listbox-resources.ts
+++ b/packages/sn-filter-pane/src/hooks/listbox/get-listbox-resources.ts
@@ -4,8 +4,11 @@ async function getListboxResourcesFromIds(app: EngineAPI.IApp, ids: string[], la
   const models = await Promise.all(ids.map((id) => app.getObject(id)));
   const layouts = await Promise.all(models.map((model) => model.getLayout() as unknown as EngineAPI.IGenericListLayout));
   // add components object for styling
+  console.log('layouts', layouts)
   if(layouts && layouts.length > 0) {
-    layouts[0].components = layout['components']
+    layouts.forEach(layoutElem => {
+      layoutElem.components = layout['components'];
+    })
   };
 
   return ids.map((id: string, index: number) => ({

--- a/packages/sn-filter-pane/src/hooks/listbox/get-listbox-resources.ts
+++ b/packages/sn-filter-pane/src/hooks/listbox/get-listbox-resources.ts
@@ -1,8 +1,12 @@
 import { IFilterPaneLayout, ListboxResourcesArr } from '../types';
 
-async function getListboxResourcesFromIds(app: EngineAPI.IApp, ids: string[]): Promise<ListboxResourcesArr> {
+async function getListboxResourcesFromIds(app: EngineAPI.IApp, ids: string[], layout: IFilterPaneLayout): Promise<ListboxResourcesArr> {
   const models = await Promise.all(ids.map((id) => app.getObject(id)));
   const layouts = await Promise.all(models.map((model) => model.getLayout() as unknown as EngineAPI.IGenericListLayout));
+  // add components object for styling
+  if(layouts && layouts.length > 0) {
+    layouts[0].components = layout['components']
+  };
 
   return ids.map((id: string, index: number) => ({
     id,
@@ -13,5 +17,5 @@ async function getListboxResourcesFromIds(app: EngineAPI.IApp, ids: string[]): P
 
 export default async function getListBoxResources(app: EngineAPI.IApp, layout: IFilterPaneLayout): Promise<ListboxResourcesArr> {
   const childIds = layout?.qChildList?.qItems.map((item) => item.qInfo.qId) || [];
-  return getListboxResourcesFromIds(app, childIds);
+  return getListboxResourcesFromIds(app, childIds, layout);
 }


### PR DESCRIPTION
Add layout components for listbox resources, so that the listbox is able to get the styling components from filterpane layout, which are used for styling from styling panel.
 https://github.com/qlik-oss/nebula.js/pull/1339
 
<img width="703" alt="Screenshot 2023-08-22 at 17 13 29" src="https://github.com/qlik-oss/sn-list-objects/assets/13185716/ca3044f4-2db7-4b68-b677-93d255cd726d">

 