### PR TITLE
feat: add selected state styling definition

### DIFF
--- a/packages/sn-filter-pane/src/ext/property-panel/settings/presentation/styling-panel-def.js
+++ b/packages/sn-filter-pane/src/ext/property-panel/settings/presentation/styling-panel-def.js
@@ -103,6 +103,49 @@ const stylingPanelDef = {
           },
         },
       },
+      selectionStateSection: {
+        component: 'panel-section',
+            translation: 'properties.selectionState',
+            items: {
+              selectionItems: {
+                component: 'items',
+                ref: 'components',
+                key: 'listBox',
+                items: {
+                  selectedColor: {
+                      show: true,
+                      ref: 'palette.selected',
+                      type: 'object',
+                      component: 'color-picker',
+                      translation: 'Selected',
+                      defaultValue(item, data, args) {
+                          return { color: "#009845" };
+                      }
+                  },
+                  alternativeColor: {
+                      show: true,
+                      ref: 'palette.alternative',
+                      type: 'object',
+                      component: 'color-picker',
+                      translation: 'Alternative',
+                      defaultValue(item, data, args) {
+                          return { color: "#E4E4E4" };
+                      }
+                  },
+                  excludedColor: {
+                      show: true,
+                      ref: 'palette.excluded',
+                      type: 'object',
+                      component: 'color-picker',
+                      translation: 'Excluded',
+                      defaultValue(item, data, args) {
+                          return { color: "#BEBEBE" };
+                      }
+                  },
+              }
+            }
+        },
+      }
     },
   },
 };


### PR DESCRIPTION
Draft for adding the selection state color options to the styling panel definition in filter pane
Probably default values should not be hardcoded but I'm not getting them from current theme

To fix: width of selected colors components in the styling panel to be aligned with items above + missing translations



<img width="703" alt="Screenshot 2023-09-08 at 07 15 49" src="https://github.com/qlik-oss/sn-list-objects/assets/13185716/863448f7-d404-4c8c-bdcf-a3d08538067c">


