### PR TITLE
fix: prevent hidden item

### DIFF
--- a/packages/sn-filter-pane/src/components/ListboxGrid/use-handle-resize.ts
+++ b/packages/sn-filter-pane/src/components/ListboxGrid/use-handle-resize.ts
@@ -128,7 +128,7 @@ export default function useHandleResize({
       }
     }
 
-    if (!isSingleColumn) {
+    if (!isSingleColumn && overflowing.length > 0) {
       // Ensure the overflow column adjusts for the overflow dropdown button, if any.
       adjustOverflowColumn(columnsTemp[columnsTemp.length - 1], size, overflowing);
     }


### PR DESCRIPTION
Prevent the last item from being hidden when height is small and multiple columns.

## Before fix:
<img width="1539" alt="image" src="https://github.com/qlik-oss/sn-list-objects/assets/5780544/070f092c-a5f1-477b-b79e-d2f1daaaa5b1">


## After fix:
<img width="799" alt="image" src="https://github.com/qlik-oss/sn-list-objects/assets/5780544/0713ac83-fbce-41c2-b3a6-c8dc65241028">
