### PR TITLE
fix: hover color and expand last item

### DIFF
--- a/packages/sn-filter-pane/src/components/ExpandButton.tsx
+++ b/packages/sn-filter-pane/src/components/ExpandButton.tsx
@@ -32,12 +32,14 @@ export const ExpandButton = ({
       height = containerSize.height - POPOVER_CONTAINER_PADDING - 1;
     }
     return {
-      backgroundColor: styles?.listbox.backgroundColor,
-      width: '100%',
-      height,
-      border: '1px solid #B3B3B3',
-      borderRadius: '3px',
-      justifyContent: 'end',
+      '&.MuiButton-root': {
+        justifyContent: 'end',
+        width: '100%',
+        height,
+        borderRadius: '3px',
+        backgroundColor: styles?.listbox.backgroundColor,
+        border: '1px solid #B3B3B3',
+      },
     };
   });
 

--- a/packages/sn-filter-pane/src/components/ListboxGrid/ListboxGrid.tsx
+++ b/packages/sn-filter-pane/src/components/ListboxGrid/ListboxGrid.tsx
@@ -124,20 +124,20 @@ function ListboxGrid({ stores }: { stores: IStores }) {
         overflow="hidden"
       >
 
-        {!!columns?.length && columns?.map((column: IColumn, i: number) => (
-          <ColumnGrid key={i} widthPercent={100 / columns.length}>
-            <Column lastColumn={!isRtl ? columns.length === i + 1 : i === 0}>
-              {!!column?.items?.length && column.items.map((item: IListboxResource, j: number) => (
+        {!!columns?.length && columns?.map((column: IColumn, columnIndex: number) => (
+          <ColumnGrid key={columnIndex} widthPercent={100 / columns.length}>
+            <Column lastColumn={!isRtl ? columns.length === columnIndex + 1 : columnIndex === 0}>
+              {!!column?.items?.length && column.items.map((item: IListboxResource, itemIndex: number) => (
                 <ColumnItem
                   key={item.id}
-                  lastItem={column.items?.length === j + 1 && !column.hiddenItems}
+                  lastItem={column.items?.length === itemIndex + 1 && !column.hiddenItems}
                   listItem={item}
                 >
                   {item.expand
                     ? <ListboxContainer
                       layout={item.layout}
                       model={item.model}
-                      borderBottom={(column.items?.length === j + 1) || !item.fullyExpanded}
+                      borderBottom={(column.items?.length === itemIndex + 1) || !item.fullyExpanded}
                       handleActive={handleActive}
                       stores={stores}
                     ></ListboxContainer>

--- a/packages/sn-filter-pane/src/components/ListboxGrid/distribute-resources.ts
+++ b/packages/sn-filter-pane/src/components/ListboxGrid/distribute-resources.ts
@@ -152,13 +152,6 @@ function expandUntilFull(sortedItems: IListboxResource[] | undefined, initialLef
   let expandedHeight;
   let leftOverHeight = initialLeftOverHeight;
 
-  // sortedItems.forEach((itm) => {
-  //   if (!itm.alwaysExpanded) {
-  //     itm.expand = false;
-  //     itm.height = DEFAULT_CSS_HEIGHT;
-  //   }
-  // });
-
   for (i = 0; i < sortedItems.length; i++) {
     item = sortedItems[i];
     if (item.cardinal && !item.fullyExpanded) {

--- a/packages/sn-filter-pane/src/components/ListboxGrid/use-handle-resize.ts
+++ b/packages/sn-filter-pane/src/components/ListboxGrid/use-handle-resize.ts
@@ -139,15 +139,6 @@ export default function useHandleResize({
 
     sortColumnItemsByFieldOrder(columnsTemp, resources);
 
-    // Now that we have the expected field order in place, ensure that the last
-    // non-collapsed item of the first column fills out the remaining space.
-    const colItems = columnsTemp[0]?.items || [];
-    const lastItem = colItems[colItems.length - 1];
-    if (lastItem && !columnsTemp[0]?.hiddenItems && !lastItem.neverExpanded) {
-      const pxHeight = size.height - estimateColumnHeight({ ...columnsTemp, items: colItems.slice(0, colItems.length - 1) });
-      lastItem.height = pxHeight ? `${pxHeight}px` : DEFAULT_CSS_HEIGHT;
-    }
-
     setOverflowingResources(overflowing);
     setColumns(columnsTemp);
     prepareRenderTracker(expandedItemsCount, renderTracker);

--- a/packages/sn-filter-pane/src/components/ListboxGrid/use-handle-resize.ts
+++ b/packages/sn-filter-pane/src/components/ListboxGrid/use-handle-resize.ts
@@ -140,11 +140,12 @@ export default function useHandleResize({
     sortColumnItemsByFieldOrder(columnsTemp, resources);
 
     // Now that we have the expected field order in place, ensure that the last
-    // non-collapsed item of the first column is expanded to 100%, to fill out the space.
+    // non-collapsed item of the first column fills out the remaining space.
     const colItems = columnsTemp[0]?.items || [];
     const lastItem = colItems[colItems.length - 1];
     if (lastItem && !columnsTemp[0]?.hiddenItems && !lastItem.neverExpanded) {
-      lastItem.height = DEFAULT_CSS_HEIGHT;
+      const pxHeight = size.height - estimateColumnHeight({ ...columnsTemp, items: colItems.slice(0, colItems.length - 1) });
+      lastItem.height = pxHeight ? `${pxHeight}px` : DEFAULT_CSS_HEIGHT;
     }
 
     setOverflowingResources(overflowing);

--- a/packages/sn-filter-pane/src/components/ListboxGrid/use-handle-resize.ts
+++ b/packages/sn-filter-pane/src/components/ListboxGrid/use-handle-resize.ts
@@ -17,6 +17,7 @@ import { IListboxResource } from '../../hooks/types';
 import { IStore } from '../../store';
 import { getSadItems, moveItemToOverflow } from './distribute-always-expanded';
 import { estimateColumnHeight } from './distribute-resources-counting';
+import { DEFAULT_CSS_HEIGHT } from './grid-constants';
 
 const prepareRenderTracker = (listboxCount: number, renderTracker?: RenderTrackerService) => {
   renderTracker?.setNumberOfListboxes(listboxCount);
@@ -137,6 +138,14 @@ export default function useHandleResize({
     ({ columns: columnsTemp, expandedItemsCount } = calculateExpandPriority(columnsTemp, size, expandProps, isSmallDevice));
 
     sortColumnItemsByFieldOrder(columnsTemp, resources);
+
+    // Now that we have the expected field order in place, ensure that the last
+    // non-collapsed item of the first column is expanded to 100%, to fill out the space.
+    const colItems = columnsTemp[0]?.items || [];
+    const lastItem = colItems[colItems.length - 1];
+    if (!lastItem.neverExpanded) {
+      lastItem.height = DEFAULT_CSS_HEIGHT;
+    }
 
     setOverflowingResources(overflowing);
     setColumns(columnsTemp);

--- a/packages/sn-filter-pane/src/components/ListboxGrid/use-handle-resize.ts
+++ b/packages/sn-filter-pane/src/components/ListboxGrid/use-handle-resize.ts
@@ -143,7 +143,7 @@ export default function useHandleResize({
     // non-collapsed item of the first column is expanded to 100%, to fill out the space.
     const colItems = columnsTemp[0]?.items || [];
     const lastItem = colItems[colItems.length - 1];
-    if (!lastItem.neverExpanded) {
+    if (lastItem && !columnsTemp[0]?.hiddenItems && !lastItem.neverExpanded) {
       lastItem.height = DEFAULT_CSS_HEIGHT;
     }
 

--- a/packages/sn-filter-pane/src/components/ListboxGrid/use-handle-resize.ts
+++ b/packages/sn-filter-pane/src/components/ListboxGrid/use-handle-resize.ts
@@ -17,7 +17,6 @@ import { IListboxResource } from '../../hooks/types';
 import { IStore } from '../../store';
 import { getSadItems, moveItemToOverflow } from './distribute-always-expanded';
 import { estimateColumnHeight } from './distribute-resources-counting';
-import { DEFAULT_CSS_HEIGHT } from './grid-constants';
 
 const prepareRenderTracker = (listboxCount: number, renderTracker?: RenderTrackerService) => {
   renderTracker?.setNumberOfListboxes(listboxCount);


### PR DESCRIPTION
#### Bug fixes

- Ensure wrapping/expand button's color is kept on hover (previously overridden by mui's style on hover)
- ~Expand the last listbox item in first column to fill out the remaining space (this is how it worked before introducing `collapseMode`)~


##### Before (expand button's hover color overridden):
https://github.com/qlik-oss/sn-list-objects/assets/5780544/01c326e6-2061-4342-a158-969709d47c86



