### PR TITLE
fix(sn-filter-pane): conform to nebulas naming of background image properties

### DIFF
--- a/packages/sn-filter-pane/src/ext/property-panel/settings/presentation/styling-panel-def.js
+++ b/packages/sn-filter-pane/src/ext/property-panel/settings/presentation/styling-panel-def.js
@@ -274,12 +274,12 @@ export default function getStyling(env) {
                           data.background = data.background || {};
                           data.background.image = data.background.image || {};
                           data.background.image.qStaticContentUrlDef = data.background.image.qStaticContentUrlDef || {};
-                          data.background.image.url = data.background.image.url || {};
+                          data.background.image.mediaUrl = data.background.image.mediaUrl || {};
                         },
                       },
                       MediaLibrary: {
                         component: 'media-library-button',
-                        ref: 'background.image.url',
+                        ref: 'background.image.mediaUrl',
                         translation: 'MediaLibrary.Header',
                         show(data) {
                           return data?.background?.image?.mode === 'media';
@@ -287,7 +287,7 @@ export default function getStyling(env) {
                       },
                       imageSize: {
                         component: 'dropdown',
-                        ref: 'background.image.size',
+                        ref: 'background.image.sizing',
                         defaultValue: styleDefaults.BACKGROUND_SIZE,
                         options: [
                           {
@@ -321,17 +321,17 @@ export default function getStyling(env) {
                           }
                         },
                         show: (data) => data?.background?.image?.mode === 'media'
-                          && !!data?.background?.image?.url?.qStaticContentUrlDef?.qUrl,
+                          && !!data?.background?.image?.mediaUrl?.qStaticContentUrlDef?.qUrl,
                       },
                       position: {
                         component: 'position-grid',
                         ref: 'background.image.position',
                         translation: 'properties.backgroundImage.position',
                         defaultValue: styleDefaults.BGIMAGE_POSITION,
-                        currentSizeRef: 'background.size',
+                        currentSizeRef: 'background.sizing',
                         show: (data) => data?.background?.image?.mode === 'media'
-                          && data?.background?.image?.url?.qStaticContentUrlDef?.qUrl
-                          && data?.background?.image?.size !== 'stretchFit',
+                          && data?.background?.image?.mediaUrl?.qStaticContentUrlDef?.qUrl
+                          && data?.background?.image?.sizing !== 'stretchFit',
                       },
                     },
                   },

--- a/packages/sn-filter-pane/src/hooks/styling-utils.ts
+++ b/packages/sn-filter-pane/src/hooks/styling-utils.ts
@@ -30,10 +30,8 @@ type ImageDefComponent = {
     expressionUrl?: string;
     mode?: 'media' | 'expression';
     mediaUrl?: { qStaticContentUrl?: { qUrl?: string } };
-    url?: { qStaticContentUrl?: { qUrl?: string } };
     position?: 'top-left' | 'top-center' | 'top-right' | 'center-left' | 'center-center' | 'center-right' | 'bottom-left' | 'bottom-center' | 'bottom-right';
     sizing?: ISizing;
-    size?: ISizing;
   }
 };
 
@@ -68,7 +66,7 @@ function getBackgroundPosition(bgComp: ImageDefComponent) {
 
 function getBackgroundSize(bgComp: ImageDefComponent) {
   let bkgImageSize = imageSizingToCssProperty.originalSize;
-  const size = bgComp?.bgImage?.sizing || bgComp?.bgImage?.size;
+  const size = bgComp?.bgImage?.sizing;
   if (size) {
     bkgImageSize = imageSizingToCssProperty[size];
   }
@@ -85,7 +83,7 @@ export function resolveBgImage(bgComp: ImageDefComponent, app?: EngineAPI.IApp) 
   if (bgImageDef) {
     let url = '' as string | undefined;
     if (bgImageDef.mode === 'media' || bgComp.useImage === 'media') {
-      const urlObj = bgImageDef?.mediaUrl || bgImageDef?.url;
+      const urlObj = bgImageDef?.mediaUrl;
       const { qUrl } = urlObj?.qStaticContentUrl || {};
       url = qUrl ? decodeURIComponent(qUrl) : undefined;
       url = resolveImageUrl(app, url);

--- a/packages/sn-filter-pane/src/hooks/types/components.d.ts
+++ b/packages/sn-filter-pane/src/hooks/types/components.d.ts
@@ -37,10 +37,8 @@ export type IThemeComponent = {
       expressionUrl?: string;
       mode?: 'media' | 'expression';
       mediaUrl?: { qStaticContentUrl?: { qUrl?: string } };
-      url?: { qStaticContentUrl?: { qUrl?: string } };
       position?: 'top-left' | 'top-center' | 'top-right' | 'center-left' | 'center-center' | 'center-right' | 'bottom-left' | 'bottom-center' | 'bottom-right';
       sizing?: ISizing;
-      size?: ISizing;
     }
   };
 };


### PR DESCRIPTION
Conform to nebulas naming of background image properties (not using naming as in e.g. ActionButton) as it is confusing to have two different ways of implementing the same thing.