### PR TITLE
fix(sn-filter-pane): adjust tab names

### DIFF
--- a/packages/sn-filter-pane/src/ext/property-panel/settings/presentation/styling-panel-def.ts
+++ b/packages/sn-filter-pane/src/ext/property-panel/settings/presentation/styling-panel-def.ts
@@ -40,6 +40,8 @@ export default function getStyling(env: IEnv) {
       chartType: 'filterpane',
       translation: 'LayerStyleEditor.component.styling',
       chartTitle: 'Object.FilterPane',
+      generalTabTitle: 'Object.FilterPane',
+      tabTitle: 'Object.Listboxes',
       useBackground: true,
       subtitle: 'LayerStyleEditor.component.styling',
       useGeneral: true,


### PR DESCRIPTION
Change translations of tabs to make it clearer if we are editing the Filterpane or Listboxes' style.


## Before

<img width="249" alt="image" src="https://github.com/qlik-oss/sn-list-objects/assets/5780544/78a5b5a2-2e11-4f3c-8d16-4028a5d8f14a">


## After

<img width="249" alt="image" src="https://github.com/qlik-oss/sn-list-objects/assets/5780544/830c3956-567c-42b8-821a-b5d7fdcf7989">
