### PR TITLE
fix(sn-filter-pane): reset zoom for all scenarios

### DIFF
--- a/packages/sn-filter-pane/src/components/ListboxGrid/ListboxGrid.tsx
+++ b/packages/sn-filter-pane/src/components/ListboxGrid/ListboxGrid.tsx
@@ -1,5 +1,4 @@
 import React, {
-  useCallback,
   useEffect, useRef, useSyncExternalStore,
 } from 'react';
 import { Grid } from '@mui/material';

--- a/packages/sn-filter-pane/src/components/ListboxGrid/ListboxGrid.tsx
+++ b/packages/sn-filter-pane/src/components/ListboxGrid/ListboxGrid.tsx
@@ -1,4 +1,5 @@
 import React, {
+  useCallback,
   useEffect, useRef, useSyncExternalStore,
 } from 'react';
 import { Grid } from '@mui/material';
@@ -21,6 +22,7 @@ import KEYS from '../keys';
 import useFocusListener from '../../hooks/use-focus-listener';
 import findNextIndex from './find-next-index';
 import { IEnv } from '../../types/types';
+import resetZoom from '../../utils/reset-zoom';
 
 function ListboxGrid({ stores }: { stores: IStores }) {
   const { store, resourceStore } = stores;
@@ -89,6 +91,13 @@ function ListboxGrid({ stores }: { stores: IStores }) {
     preventDefaultBehavior(event);
   };
 
+  const handleFocus = useCallback(() => {
+    // Reset focus on small devices due to auto focus.
+    if (sense?.isSmallDevice?.()) {
+      resetZoom();
+    }
+  }, [sense?.isSmallDevice?.()]);
+
   useFocusListener(gridRef, keyboard);
 
   const isRtl = options.direction === 'rtl';
@@ -116,6 +125,7 @@ function ListboxGrid({ stores }: { stores: IStores }) {
         className="filter-pane-container"
         container
         onKeyDown={handleKeyDown}
+        onFocus={handleFocus}
         sx={{ flexDirection: isRtl ? 'row-reverse' : 'row' }}
         columns={columns?.length}
         ref={gridRef as unknown as () => HTMLObjectElement}

--- a/packages/sn-filter-pane/src/components/ListboxGrid/ListboxGrid.tsx
+++ b/packages/sn-filter-pane/src/components/ListboxGrid/ListboxGrid.tsx
@@ -91,12 +91,7 @@ function ListboxGrid({ stores }: { stores: IStores }) {
     preventDefaultBehavior(event);
   };
 
-  const handleFocus = useCallback(() => {
-    // Reset focus on small devices due to auto focus.
-    if (sense?.isSmallDevice?.()) {
-      resetZoom();
-    }
-  }, [sense?.isSmallDevice?.()]);
+  const handleFocus = sense?.isSmallDevice?.() ? () => resetZoom() : undefined;
 
   useFocusListener(gridRef, keyboard);
 

--- a/packages/sn-filter-pane/src/components/ListboxPopoverContainer.tsx
+++ b/packages/sn-filter-pane/src/components/ListboxPopoverContainer.tsx
@@ -61,13 +61,6 @@ const StyledPopover = styled(Popover, { shouldForwardProp: (p: string) => !['isS
   } : {},
 }));
 
-function resetZoom() {
-  const viewportMetaTag = document.querySelector('meta[name="viewport"]');
-  if (viewportMetaTag instanceof HTMLMetaElement) {
-    viewportMetaTag.content = 'width=device-width, minimum-scale=1.0, maximum-scale=1.0, initial-scale=1.0';
-  }
-}
-
 /**
  * If a single resource is passed to this component a FoldedListbox is rendered.
  * When the FoldedListbox is clicked, a Listbox is rendered in a Popover.
@@ -87,10 +80,6 @@ export const ListboxPopoverContainer = ({ resources, stores }: FoldedPopoverProp
   const handleOpen = ({ event }: FoldedListboxClickEvent | { event: React.MouseEvent<HTMLButtonElement, MouseEvent> }) => {
     if (event.currentTarget.contains(event.target as Node) && !constraints?.active) {
       setPopoverOpen(true);
-      if (isSmallDevice) {
-        // Autofocus can cause the browser to zoom so we need to reset zoom.
-        resetZoom();
-      }
     }
   };
   const handleClose = () => {

--- a/packages/sn-filter-pane/src/utils/reset-zoom.ts
+++ b/packages/sn-filter-pane/src/utils/reset-zoom.ts
@@ -1,0 +1,11 @@
+/**
+ * Run this on small devices to reset the zoom. Required when focusing
+ * an input field and the browser auto zooms the page. Browsers do not
+ * expose any API for handling this currently.
+ */
+export default function resetZoom() {
+  const viewportMetaTag = document.querySelector('meta[name="viewport"]');
+  if (viewportMetaTag instanceof HTMLMetaElement) {
+    viewportMetaTag.content = 'width=device-width, minimum-scale=1.0, maximum-scale=1.0, initial-scale=1.0';
+  }
+}


### PR DESCRIPTION
## Problem

When opening the search field on a mobile device (iOS), the browser zooms in, hiding parts of the listbox and search field.

This has been fixed before with https://github.com/qlik-oss/sn-list-objects/pull/365 but not covering all scenarios.

The previous fix called the new utility function `resetZoom()` when opening up a folded listbox. This ignored that scenario where we don't have a folded listbox from the start.

## Fix

In this fix, `resetZoom()` is called when focusing the Filter pane container itself. It is still called only on small devices (as defined by Sense). In the tests (see example in screen recording) it works fine and is not called extensively either.

https://github.com/qlik-oss/sn-list-objects/assets/5780544/6b43cfed-df7a-4121-a184-4b59f9c39b18