### PR TITLE
fix(sn-filter-pane): move background definition so reset only affects this setting

### DIFF
--- a/packages/sn-filter-pane/src/ext/property-panel/settings/presentation/styling-panel-def.ts
+++ b/packages/sn-filter-pane/src/ext/property-panel/settings/presentation/styling-panel-def.ts
@@ -215,11 +215,11 @@ export default function getStyling(env: IEnv) {
             translation: 'properties.background.options',
             items: {
               background: {
+                ref: 'components',
+                key: 'theme',
+                type: 'items',
                 items: {
                   backgroundColor: {
-                    ref: 'components',
-                    key: 'theme',
-                    type: 'items',
                     items: {
                       useColorExpression: {
                         type: 'boolean',

--- a/packages/sn-filter-pane/src/ext/property-panel/settings/presentation/styling-panel-def.ts
+++ b/packages/sn-filter-pane/src/ext/property-panel/settings/presentation/styling-panel-def.ts
@@ -4,6 +4,7 @@ import { fontResolver as createFontResolver } from 'qlik-chart-modules';
 import { getFontSizes, parseFontWeight } from './styling-utils/font-utils';
 import styleDefaults from './style-defaults';
 import { IEnv } from '../../../../types/types';
+import { IComponent } from '../../../../hooks/types/components';
 
 export default function getStyling(env: IEnv) {
   const { translator, flags, sense } = env || {};
@@ -213,13 +214,21 @@ export default function getStyling(env: IEnv) {
           backgroundOptions: {
             component: 'panel-section',
             translation: 'properties.background.options',
+            reset(data: any, _def: any, args: any) {
+              // Without this reset function, the entire section will be reset.
+              const themeComponent = data?.components?.find((component: IComponent) => component?.key === 'theme');
+              if (themeComponent) {
+                themeComponent.background = {};
+                args?.saveProperties?.(args.properties); // explicit save needed
+              }
+            },
             items: {
               background: {
-                ref: 'components',
-                key: 'theme',
-                type: 'items',
                 items: {
                   backgroundColor: {
+                    ref: 'components',
+                    key: 'theme',
+                    type: 'items',
                     items: {
                       useColorExpression: {
                         type: 'boolean',

--- a/packages/sn-filter-pane/src/hooks/types/components.d.ts
+++ b/packages/sn-filter-pane/src/hooks/types/components.d.ts
@@ -67,11 +67,12 @@ export interface IStyles {
   listbox: {
     background: {
       color?: string;
-      image?: {
-        url?: string;
-        position?: string;
-        size?: string;
-      }
+      backgroundColor?: string;
+      backgroundImage?: string;
+      backgroundRepeat?: string;
+      backgroundSize?: string;
+      backgroundPosition?: string;
+      opacity?: number;
     };
     color?: string;
   }


### PR DESCRIPTION
## The issue

The reset button in the background section currently resets all Listbox styling settings.

![image](https://github.com/qlik-oss/sn-list-objects/assets/5780544/7de32aef-e567-47ad-9b1d-991c8c537c59)

## The fix

Added a reset function for this subsection to handle reset explicitly (resetting the `themeComponent.background` object).

Also added missing TS types.