### PR TITLE
fix(sn-filter-pane): disable popover messing with body tag

### DIFF
--- a/packages/sn-filter-pane/src/components/ListboxPopoverContainer.tsx
+++ b/packages/sn-filter-pane/src/components/ListboxPopoverContainer.tsx
@@ -226,6 +226,7 @@ export const ListboxPopoverContainer = ({ resources, stores }: FoldedPopoverProp
         anchorEl={containerRef.current}
         transitionDuration={transitionDuration}
         isSmallDevice={isSmallDevice}
+        disableScrollLock
         anchorOrigin={{
           vertical: 'bottom',
           horizontal: 'left',


### PR DESCRIPTION
Currently, the mui popover modifies the body tag with `overflow: hidden` and `padding-right: 17px` on Windows, to compensate for the scrollbar. This can be disable with: `disableScrollLock`. Since we use a backdrop that prevents interactions, there should not be any side-effects that I can think of.