### PR TITLE
fix: update then child object layout changes

### DIFF
--- a/packages/sn-filter-pane/src/hooks/listbox/get-listbox-resources.ts
+++ b/packages/sn-filter-pane/src/hooks/listbox/get-listbox-resources.ts
@@ -1,17 +1,117 @@
-import { IFilterPaneLayout, ListboxResourcesArr } from '../types';
+import { useState } from '@nebula.js/stardust';
+import { IStores } from '../../store';
+import { IFilterPaneLayout, IListLayout, ListboxResourcesArr } from '../types';
 
-async function getListboxResourcesFromIds(app: EngineAPI.IApp, ids: string[]): Promise<ListboxResourcesArr> {
-  const models = await Promise.all(ids.map((id) => app.getObject(id)));
-  const layouts = await Promise.all(models.map((model) => model.getLayout() as unknown as EngineAPI.IGenericListLayout)) || [];
 
-  return ids.map((id: string, index: number) => ({
-    id,
-    model: models[index],
-    layout: layouts[index],
-  }));
+class ChildObjectLayoutFetcher {
+  private app: EngineAPI.IApp;
+  private onUpdate: (resources: ListboxResourcesArr) => void;
+  private childIds: string[] = [];
+  private childStates: Record<string, ChildState> = {};
+
+  constructor(app: EngineAPI.IApp, onUpdate: (resources: ListboxResourcesArr) => void) {
+    this.app = app;
+    this.onUpdate = onUpdate;
+  }
+
+  updateLayout(id: string, layout: IListLayout) {
+    const state = this.childStates[id];
+    if (!state) {
+      return;
+    }
+    state.layout = layout;
+    const allLayoutsAreReady = this.childIds.every((id) => this.childStates[id].layout !== undefined);
+    if (allLayoutsAreReady) {
+      const resources = this.childIds.map((id) => ({
+        id,
+        model: this.childStates[id].model!,
+        layout: this.childStates[id].layout!,
+      }));
+      this.onUpdate(resources);
+    }
+  }
+
+  removeChild(id: string) {
+    const state = this.childStates[id];
+    if(!state) {
+      return;
+    }
+    this.childIds = this.childIds.filter(childId => childId !== id);
+    delete this.childStates[id];
+    state.destroy();
+  }
+
+  async addChild(id: string) {
+    this.childStates[id] = {
+      model: undefined,
+      layout: undefined,
+      destroy: () => {},
+    }
+    const model = await this.app.getObject(id);
+    const state = this.childStates[id];
+    if (!state) {
+      return;
+    }
+    state.model = model;
+    const onChanged = async () => {
+      const layout = await model.getLayout() as unknown as IListLayout;
+      this.updateLayout(id, layout);
+    };
+    model.on('changed', onChanged);
+    const stopListen = () => {
+      // @ts-expect-error removeListener missing frm enigma types
+      model.removeListener('changed', onChanged);
+    };
+    state.destroy = stopListen;
+
+    onChanged();
+  }
+
+  updateChildren(newChildIds: string[]) {
+    const addedIds = newChildIds.filter(id => !this.childIds.includes(id));
+    const removedId = this.childIds.filter(id => !newChildIds.includes(id));
+    this.childIds = newChildIds;
+    for(const id of removedId) {
+      this.removeChild(id);
+    }
+    for(const id of addedIds) {
+      this.addChild(id);
+    }
+  }
+
+  update(fpLayout: IFilterPaneLayout) {
+    const childIds = fpLayout?.qChildList?.qItems.map((item) => item.qInfo.qId);
+    if (!childIds) {
+      return;
+    }
+    this.updateChildren(childIds);
+  }
 }
 
-export default async function getListBoxResources(app: EngineAPI.IApp, fpLayout: IFilterPaneLayout): Promise<ListboxResourcesArr> {
-  const childIds = fpLayout?.qChildList?.qItems.map((item) => item.qInfo.qId) || [];
-  return getListboxResourcesFromIds(app, childIds);
+function useRef<T>() {
+  const [ref] = useState<{ current: undefined | T }>({ current: undefined });
+  return ref;
+}
+
+export default function useListBoxResources(stores: IStores) {
+  const [resourcesReady, setResourcesReady] = useState<boolean>(false);
+  const { store, resourceStore } = stores;
+  const { app, fpLayout } = store.getState();
+  const childObjectLayoutFetcherRef = useRef<ChildObjectLayoutFetcher>();
+  if (!childObjectLayoutFetcherRef.current && app && resourceStore) {
+    childObjectLayoutFetcherRef.current = new ChildObjectLayoutFetcher(app, (resources) => {
+      resourceStore.setState({ resources })
+      setResourcesReady(true);
+    })
+  }
+  if (childObjectLayoutFetcherRef.current && fpLayout) {
+    childObjectLayoutFetcherRef.current.update(fpLayout)
+  }
+  return { resourcesReady };
+}
+
+interface ChildState {
+  model: EngineAPI.IGenericObject | undefined;
+  layout: IListLayout | undefined;
+  destroy(): void;
 }

--- a/packages/sn-filter-pane/src/hooks/use-render.ts
+++ b/packages/sn-filter-pane/src/hooks/use-render.ts
@@ -1,23 +1,16 @@
-import { useEffect, useElement, useState } from '@nebula.js/stardust';
+import { useEffect, useElement } from '@nebula.js/stardust';
 import type { IStores } from '../store';
-import getListBoxResources from './listbox/get-listbox-resources';
-import { IContainerElement, ListboxResourcesArr } from './types';
+import useListBoxResources from './listbox/get-listbox-resources';
+import { IContainerElement } from './types';
 import { render, teardown } from '../components/root';
 
 export default function useRender(stores: IStores) {
-  const { store, resourceStore } = stores;
-  const [resourcesReady, setResourcesReady] = useState<boolean>(false);
+  const { store } = stores;
 
   const { app, fpLayout } = store.getState();
   const containerElement = <IContainerElement>useElement();
 
-  if (app && fpLayout) {
-    getListBoxResources(app, fpLayout).then((resArr: ListboxResourcesArr) => {
-      // setState will trigger a re-render of ListboxGrid, needed if a Listbox changes size (eg. dense mode)
-      resourceStore.setState({ resources: resArr });
-      setResourcesReady(true);
-    });
-  }
+  const { resourcesReady } = useListBoxResources(stores);
 
   // Trigger a re-render only when components have changed in the filterpane layout.
   // (Note that useEffect equality check is shallow and therefore requires a hash.)


### PR DESCRIPTION
fix that update in child listboxes did not update the filterpane
Selection & Header for folded listboxes
and anything that affected layout & if the listbox should be collapsed (ex: Collapse Listbox setting)

some rist of performance degrade as there are more update that make it re-render