### PR TITLE
fix: should not preventDefaultBehaviour on keys that are not handled by the component

### DIFF
--- a/packages/sn-filter-pane/src/components/ListboxGrid/ListboxGrid.tsx
+++ b/packages/sn-filter-pane/src/components/ListboxGrid/ListboxGrid.tsx
@@ -71,6 +71,7 @@ function ListboxGrid({ stores }: { stores: IStores }) {
         // @ts-ignore
         keyboard.blur?.(true);
       }
+      preventDefaultBehavior(event);
     } else if ([KEYS.LEFT, KEYS.RIGHT, KEYS.UP, KEYS.DOWN].includes(event.key)) {
       let elementToFocus;
       const listboxList = gridRef?.current?.querySelectorAll && gridRef?.current?.querySelectorAll<HTMLElement>('.listbox-container,.listbox-popover-container');
@@ -86,8 +87,8 @@ function ListboxGrid({ stores }: { stores: IStores }) {
           elementToFocus.focus();
         }
       }
+      preventDefaultBehavior(event);
     }
-    preventDefaultBehavior(event);
   };
 
   const handleFocus = sense?.isSmallDevice?.() ? () => resetZoom() : undefined;


### PR DESCRIPTION
When using filterpane in mashup with `keyboard.enabled = false` we want to let the keyboard navigation being handled by default webbrowser handler. preventDefault on on key events that are not handled by this component prevent default behaviour from working properly. 
Example on this is when user tabs to navigate to different listboxes. Without this fix user can't tab pass the row of first listbox.